### PR TITLE
Add image to socials for Static Page

### DIFF
--- a/Sources/Ignite/Elements/Head.swift
+++ b/Sources/Ignite/Elements/Head.swift
@@ -58,6 +58,10 @@ public struct Head: HTMLRootElement {
             }
 
             MetaLink(href: page.url, rel: "canonical")
+            
+            if let favicon = context.site.favicon {
+                MetaLink(href: favicon, rel: .icon)
+            }
         }
 
         items += MetaTag.socialSharingTags(for: page, context: context)

--- a/Sources/Ignite/Framework/Site.swift
+++ b/Sources/Ignite/Framework/Site.swift
@@ -74,6 +74,9 @@ public protocol Site {
     /// The theme to apply to your site. This is used to render all pages that don't
     /// explicitly override the theme with something custom.
     var theme: ThemeType { get }
+    
+    /// The path to the favicon
+    var favicon: URL? { get }
 
     /// An array of all the static pages you want to include in your site.
     @StaticPageBuilder var pages: [any StaticPage] { get }
@@ -129,6 +132,9 @@ extension Site {
 
     /// An empty tag page by default, which triggers no tag pages being made.
     public var tagPage: EmptyTagPage { EmptyTagPage() }
+    
+    /// The default favicon being nil
+    public var favicon: URL? { nil }
 
     /// Performs the entire publishing flow from a file in user space, e.g. main.swift
     /// or Site.swift.

--- a/Sources/Ignite/Framework/StaticPage.swift
+++ b/Sources/Ignite/Framework/StaticPage.swift
@@ -16,6 +16,9 @@ public protocol StaticPage: ThemedPage {
 
     /// The title for this page.
     var title: String { get }
+    
+    /// The image for sharing the page
+    var image: URL? { get }
 
     /// A plain-text description for this page. Defaults to an empty string.
     var description: String { get }
@@ -44,4 +47,7 @@ public extension StaticPage {
             "/\(title.lowercased().replacing(" ", with: "-"))"
         }
     }
+    
+    /// Defaults to no sharing image
+    var image: URL? { nil }
 }

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -303,6 +303,7 @@ public class PublishingContext {
             title: staticPage.title,
             description: staticPage.description,
             url: site.url.appending(path: path),
+            image: staticPage.image,
             body: body
         )
 


### PR DESCRIPTION
I have added a new variable to the protocol `StaticPage` called `image` that is an optional url to the desired image for social sharing. It hooks into rendering to plug the image url into the `Page` initialized. By default, it's set to nil.

A fix for issue #8