### PR TITLE
Allow GitHub to correctly identify the MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-Ignite
 MIT License
 
 Copyright (c) 2024 Paul Hudson and other authors.


### PR DESCRIPTION
Same problem as https://github.com/twostraws/Vortex/pull/5 👍