### PR TITLE
Added local server functionality

### DIFF
--- a/Sources/Ignite/Framework/Server.swift
+++ b/Sources/Ignite/Framework/Server.swift
@@ -1,0 +1,120 @@
+//
+// Project: Ignite
+// Author: Mark Battistella
+// Website: https://markbattistella.com
+//
+
+import Foundation
+
+/// Errors that can be thrown by the `Server` struct.
+public enum ServerError: LocalizedError {
+
+    /// Indicates that the server is already running on the specified port.
+    case serverAlreadyRunning
+
+    /// Indicates a failure to execute an AppleScript, including the error message.
+    case appleScriptExecutionFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+            case .serverAlreadyRunning:
+                "Server is already running"
+            case .appleScriptExecutionFailed(let message):
+                "AppleScript failed to execute. Error message: \(message)"
+        }
+    }
+}
+
+/// Represents a server that can serve content from a directory over HTTP.
+public struct Server {
+
+    /// The port on which the server should run.
+    public let port: Int
+
+    /// The file URL of the directory whose contents should be served.
+    public let directoryPath: URL
+
+    /// The path of the directory as a string, with spaces escaped for shell commands.
+    private let directory: String
+
+    /// Initializes a new server with the given port and directory path.
+    ///
+    /// - Parameters:
+    ///   - port: The port on which to serve the directory's contents.
+    ///   - directoryPath: The file URL of the directory to serve.
+    public init(port: Int, directoryPath: URL) {
+        self.port = port
+        self.directoryPath = directoryPath
+        self.directory = directoryPath.path(percentEncoded: false).escapingSpaces
+    }
+
+    /// Starts the server, throwing an error if it cannot start.
+    ///
+    /// This method attempts to start serving the contents of `directoryPath` over HTTP on `port`.
+    /// If the server is already running on that port, or if there's an issue with the AppleScript
+    /// execution, it throws an appropriate error.
+    ///
+    /// - Throws: A `ServerError` indicating why the server could not be started.
+    public func start() throws {
+        guard !isServerRunning(onPort: port) else {
+            throw ServerError.serverAlreadyRunning
+        }
+
+        let command = "cd \(directory) && python3 -m http.server \(port)"
+        let script = """
+        tell application "Terminal"
+            do script "\(command)"
+            activate
+        end tell
+
+        delay 2
+
+        tell application "System Events"
+            open location "http://localhost:\(port)/"
+        end tell
+        """
+
+        try runAppleScript(script)
+        print("Server started at http://localhost:\(port)/")
+    }
+
+    /// Checks whether a server is already running on the specified port.
+    ///
+    /// - Parameter port: The port to check.
+    /// - Returns: `true` if a server is already running on `port`, otherwise `false`.
+    private func isServerRunning(onPort port: Int) -> Bool {
+        let process = Process()
+        let pipe = Pipe()
+        process.launchPath = "/bin/bash"
+        process.arguments = ["-c", "lsof -i tcp:\(port)"]
+        process.standardOutput = pipe
+        process.launch()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(decoding: data, as: UTF8.self)
+        return !output.isEmpty
+    }
+
+    /// Executes an AppleScript command.
+    ///
+    /// - Parameter script: The AppleScript command to execute.
+    /// - Throws: `ServerError.appleScriptExecutionFailed` if the script fails to execute.
+    private func runAppleScript(_ script: String) throws {
+        var error: NSDictionary?
+        if let scriptObject = NSAppleScript(source: script) {
+            scriptObject.executeAndReturnError(&error)
+            if let error = error {
+                let errorMessage = error[NSLocalizedDescriptionKey] as? String ?? "Unknown error"
+                throw ServerError.appleScriptExecutionFailed(errorMessage)
+            }
+        }
+    }
+}
+
+fileprivate extension String {
+
+    /// Escapes spaces in the string for use in shell commands.
+    var escapingSpaces: String {
+        self.replacingOccurrences(of: " ", with: "\\ ")
+    }
+}

--- a/Sources/Ignite/Framework/Site.swift
+++ b/Sources/Ignite/Framework/Site.swift
@@ -78,6 +78,9 @@ public protocol Site {
     /// The path to the favicon
     var favicon: URL? { get }
 
+    /// The port to run local server of the site
+    var testingPort: Int { get }
+
     /// An array of all the static pages you want to include in your site.
     @StaticPageBuilder var pages: [any StaticPage] { get }
 
@@ -135,6 +138,9 @@ extension Site {
     
     /// The default favicon being nil
     public var favicon: URL? { nil }
+
+    /// The default testing port set to `8000`. Site will open on `http://localhost:8000`
+    public var testingPort: Int { 8000 }
 
     /// Performs the entire publishing flow from a file in user space, e.g. main.swift
     /// or Site.swift.

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -154,6 +154,7 @@ public class PublishingContext {
         try generateSiteMap()
         try generateFeed()
         try generateRobots()
+        try serveLocalSite(on: site.testingPort)
     }
 
     /// Removes all content from the Build folder, so we're okay to recreate it.
@@ -440,5 +441,20 @@ public class PublishingContext {
         } else {
             throw PublishingError.missingDefaultLayout
         }
+    }
+
+    /// Serves the site stored in the `buildDirectory` over HTTP on the specified port.
+    ///
+    /// This function initialises a `Server` with the given port and the path to the build directory
+    /// where the site's static files are located. It then attempts to start the server to serve
+    /// the site locally. If the server is already running on the specified port, or if there's
+    /// an issue starting the server, it throws an error.
+    ///
+    /// - Parameter port: The port number on which to serve the site.
+    /// - Throws: An error if the server cannot start. This could be due to the specified port
+    /// being in use, insufficient permissions, or other issues related to server startup.
+    func serveLocalSite(on port: Int) throws {
+        let server = Server(port: port, directoryPath: buildDirectory)
+        try server.start()
     }
 }


### PR DESCRIPTION
Adds in functionality to serve a local version of the Ignite website when run directly from Xcode. (Addresses issue #1)

### What this change does

1. Adds a new `testingPort` parameter to the `Site` protocol and extension.
2. Adds a new function (`serveLocalSite(on:)` to the PublishingContext
3. Adds that new function to the `publish()` method
4. Creates a new `Server` struct to serve the website directly from Xcode

### How it works

The `Server` struct has one public method - `start()` which firstly checks if the port intended for use - default `8000` - is available. If it isn't then an error is thrown.

If that port is available, then an AppleScript is called to launch a Terminal window with the `cd /Build && python3 -m http.server 8000` call.

It then launches the webpage after a 2 second delay.

On subsequent Xcode runs, the AppleScript does not fire or open new Terminal windows.

### Customisation

The use of the `testingPort` in the `Site` struct allows the user to specify a custom port for use in the event they or some other local service is using port `8000`.

### Considerations

This obviously relies on two external areas - Terminal and AppleScript. Neither should be viewed as high level risks, however there could be additional security alerts or notifications in future macOS releases, or even a deprecation of AppleScript.

Though I doubt users would be removing Terminal from their system entirely (or if even possible) this does mean that it will launch for the server opposed to other preferred apps. Not an issue, but something which may come up as a point of contention from die-hard terminal fans.

### Future expansion

Without feature creep (into the `Site` struct) or over-engineering a flag to allow the user bypass or disallow webpage serving.

Something along the lines of `--env=development` vs `--env=production`.

This way if we were to implement a Github Action or another external script to generate websites, then we don't fall into the trap of it attempting to launch Terminal or a web browser.