### PR TITLE
Move the trailing <script> chunks to the end of <body> from  <html>

### DIFF
--- a/Sources/Ignite/Elements/Body.swift
+++ b/Sources/Ignite/Elements/Body.swift
@@ -25,13 +25,27 @@ public struct Body: PageElement, HTMLRootElement {
     /// - Parameter context: The current publishing context.
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
-        let output = Group {
+        var output = Group {
             for item in items {
                 item
             }
         }
         .class("col-sm-\(context.site.pageWidth)", "mx-auto")
         .render(context: context)
+
+        output += Script(file: "/js/bootstrap.bundle.min.js").render(context: context)
+
+        if context.site.syntaxHighlighters.isEmpty == false {
+            output += Script(file: "/js/syntax-highlighting.js").render(context: context)
+        }
+
+        // Activate tooltips if there are any.
+        if output.contains(#"data-bs-toggle="tooltip""#) {
+            output += Script(code: """
+            const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+            const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+            """).render(context: context)
+        }
 
         return "<body\(attributes.description)>\(output)</body>"
     }

--- a/Sources/Ignite/Elements/HTML.swift
+++ b/Sources/Ignite/Elements/HTML.swift
@@ -40,21 +40,6 @@ public struct HTML: PageElement {
         output += "<html lang=\"\(context.site.language.rawValue)\" data-bs-theme=\"light\"\(attributes.description)>"
         output += head?.render(context: context) ?? ""
         output += body?.render(context: context) ?? ""
-
-        output += Script(file: "/js/bootstrap.bundle.min.js").render(context: context)
-
-        if context.site.syntaxHighlighters.isEmpty == false {
-            output += Script(file: "/js/syntax-highlighting.js").render(context: context)
-        }
-
-        // Activate tooltips if there are any.
-        if output.contains(#"data-bs-toggle="tooltip""#) {
-            output += Script(code: """
-            const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
-            const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
-            """).render(context: context)
-        }
-
         output += "</html>"
 
         return output


### PR DESCRIPTION
I moved the code and tested in my own copy of samples repo. Things seem to work. The testability is not obvious to me in the Ignite repo, but the existing tests pass.

I considered loading the pure scripts in the head section with a defer parameter but the tool tip script snippet looked like it needed to run last so I did not try that.
