### PR TITLE
Implement `@Environment` property wrapper

### DIFF
--- a/Sources/Ignite/Framework/Site.swift
+++ b/Sources/Ignite/Framework/Site.swift
@@ -145,7 +145,7 @@ extension Site {
     ///   The default is "Build".
     public func publish(from file: StaticString = #file, buildDirectoryPath: String = "Build") throws {
         let context = try PublishingContext(for: self, from: file, buildDirectoryPath: buildDirectoryPath)
-        environmentValues[PublishingContextKey.self] = context
+        EnvironmentValues.shared[PublishingContextKey.self] = context
 
         try context.publish()
 

--- a/Sources/Ignite/Framework/Site.swift
+++ b/Sources/Ignite/Framework/Site.swift
@@ -145,6 +145,8 @@ extension Site {
     ///   The default is "Build".
     public func publish(from file: StaticString = #file, buildDirectoryPath: String = "Build") throws {
         let context = try PublishingContext(for: self, from: file, buildDirectoryPath: buildDirectoryPath)
+        environmentValues[PublishingContextKey.self] = context
+
         try context.publish()
 
         if context.warnings.isEmpty == false {

--- a/Sources/Ignite/Publishing/Environment/Environment.swift
+++ b/Sources/Ignite/Publishing/Environment/Environment.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @propertyWrapper public struct Environment<Value> {
-    var keyPath: KeyPath<EnvironmentValues, Value>
+    private var keyPath: KeyPath<EnvironmentValues, Value>
 
     public init(_ keyPath: KeyPath<EnvironmentValues, Value>) {
         self.keyPath = keyPath

--- a/Sources/Ignite/Publishing/Environment/Environment.swift
+++ b/Sources/Ignite/Publishing/Environment/Environment.swift
@@ -7,21 +7,17 @@
 
 import Foundation
 
-fileprivate var values = EnvironmentValues()
+var environmentValues = EnvironmentValues()
 
 @propertyWrapper public struct Environment<Value> {
-    var keyPath: WritableKeyPath<EnvironmentValues, Value>
+    var keyPath: KeyPath<EnvironmentValues, Value>
 
-    public init(_ keyPath: WritableKeyPath<EnvironmentValues, Value>) {
+    public init(_ keyPath: KeyPath<EnvironmentValues, Value>) {
         self.keyPath = keyPath
     }
 
     public var wrappedValue: Value {
-        get {
-            values[keyPath: keyPath]
-        }
-        set {
-            values[keyPath: keyPath] = newValue
-        }
+        get { environmentValues[keyPath: keyPath] }
+        set { }
     }
 }

--- a/Sources/Ignite/Publishing/Environment/Environment.swift
+++ b/Sources/Ignite/Publishing/Environment/Environment.swift
@@ -7,8 +7,6 @@
 
 import Foundation
 
-var environmentValues = EnvironmentValues()
-
 @propertyWrapper public struct Environment<Value> {
     var keyPath: KeyPath<EnvironmentValues, Value>
 
@@ -17,7 +15,7 @@ var environmentValues = EnvironmentValues()
     }
 
     public var wrappedValue: Value {
-        get { environmentValues[keyPath: keyPath] }
+        get { EnvironmentValues.shared[keyPath: keyPath] }
         set { }
     }
 }

--- a/Sources/Ignite/Publishing/Environment/Environment.swift
+++ b/Sources/Ignite/Publishing/Environment/Environment.swift
@@ -1,0 +1,27 @@
+//
+// Environment.swift
+// Ignite
+// https://www.github.com/piotrekjeremicz/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+
+fileprivate var values = EnvironmentValues()
+
+@propertyWrapper public struct Environment<Value> {
+    var keyPath: WritableKeyPath<EnvironmentValues, Value>
+
+    public init(_ keyPath: WritableKeyPath<EnvironmentValues, Value>) {
+        self.keyPath = keyPath
+    }
+
+    public var wrappedValue: Value {
+        get {
+            values[keyPath: keyPath]
+        }
+        set {
+            values[keyPath: keyPath] = newValue
+        }
+    }
+}

--- a/Sources/Ignite/Publishing/Environment/Environment.swift
+++ b/Sources/Ignite/Publishing/Environment/Environment.swift
@@ -7,13 +7,35 @@
 
 import Foundation
 
+/// A property wrapper that reads a value from a view's environment.
+///
+/// Use the `Environment` property wrapper to read a value
+/// stored in a view's environment. Indicate the value to read using an
+/// ``EnvironmentValues`` key path in the property declaration.
+///
+/// You can use this property wrapper to read --- but not set --- an environment
+/// value.
+///
 @propertyWrapper public struct Environment<Value> {
+    /// A key path to a specific resulting value.
     private var keyPath: KeyPath<EnvironmentValues, Value>
 
+    /// Creates an environment property to read the specified key path.
+    ///
+    /// Don’t call this initializer directly. Instead, declare a property
+    /// with the ``Environment`` property wrapper, and provide the key path of
+    /// the environment value that the property should reflect:
+    ///
+    /// - Parameter keyPath: A key path to a specific resulting value.
     public init(_ keyPath: KeyPath<EnvironmentValues, Value>) {
         self.keyPath = keyPath
     }
 
+    /// The current value of the environment property.
+    ///
+    /// The wrapped value property provides primary access to the value's data.
+    /// However, you don't access `wrappedValue` directly. Instead, you read the
+    /// property variable created with the ``Environment`` property wrapper.
     public var wrappedValue: Value {
         get { EnvironmentValues.shared[keyPath: keyPath] }
         set { }

--- a/Sources/Ignite/Publishing/Environment/EnvironmentKey.swift
+++ b/Sources/Ignite/Publishing/Environment/EnvironmentKey.swift
@@ -1,0 +1,14 @@
+//
+// EnvironmentKey.swift
+// Ignite
+// https://www.github.com/piotrekjeremicz/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+
+public protocol EnvironmentKey {
+    associatedtype Value
+
+    static var defaultValue: Self.Value { get }
+}

--- a/Sources/Ignite/Publishing/Environment/EnvironmentKey.swift
+++ b/Sources/Ignite/Publishing/Environment/EnvironmentKey.swift
@@ -7,8 +7,16 @@
 
 import Foundation
 
+/// A key for accessing values in the environment.
+///
+/// You can create custom environment values by extending the
+/// ``EnvironmentValues`` structure with new properties.
+/// First declare a new environment key type and specify a value for the
+/// required ``defaultValue`` property.
 public protocol EnvironmentKey {
+    /// The associated type representing the type of the environment key's value.
     associatedtype Value
 
+    /// The default value for the environment key.
     static var defaultValue: Self.Value { get }
 }

--- a/Sources/Ignite/Publishing/Environment/EnvironmentValues.swift
+++ b/Sources/Ignite/Publishing/Environment/EnvironmentValues.swift
@@ -1,0 +1,24 @@
+//
+// EnvironmentValues.swift
+// Ignite
+// https://www.github.com/piotrekjeremicz/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+
+public struct EnvironmentValues {
+    private var everyValue: [ObjectIdentifier: Any] = [:]
+
+    public init() {}
+
+    public subscript<K>(key: K.Type) -> K.Value where K : EnvironmentKey {
+        get {
+            guard let value = everyValue[ObjectIdentifier(key)] as? K.Value else { return key.defaultValue }
+            return value
+        }
+        set { 
+            everyValue[ObjectIdentifier(key)] = newValue
+        }
+    }
+}

--- a/Sources/Ignite/Publishing/Environment/EnvironmentValues.swift
+++ b/Sources/Ignite/Publishing/Environment/EnvironmentValues.swift
@@ -17,8 +17,6 @@ public struct EnvironmentValues {
             guard let value = everyValue[ObjectIdentifier(key)] as? K.Value else { return key.defaultValue }
             return value
         }
-        set { 
-            everyValue[ObjectIdentifier(key)] = newValue
-        }
+        set {  everyValue[ObjectIdentifier(key)] = newValue }
     }
 }

--- a/Sources/Ignite/Publishing/Environment/EnvironmentValues.swift
+++ b/Sources/Ignite/Publishing/Environment/EnvironmentValues.swift
@@ -7,12 +7,23 @@
 
 import Foundation
 
+/// A collection of environmental values that is propagated during the publishing process.
 public struct EnvironmentValues {
+    /// Shared singleton internally used by the Ignite package to access Environment Values.
     static var shared = EnvironmentValues()
+    
+    /// A values store that contains Any value associated with ObjectIdentifier as a key.
     private var everyValue: [ObjectIdentifier: Any] = [:]
 
+    /// Creates an environment values instance.
     public init() {}
 
+    /// Accesses the environment value associated with a custom key.
+    ///
+    /// Create custom environment values by defining a key
+    /// that conforms to the ``EnvironmentKey`` protocol, and then using that
+    /// key with the subscript operator of the ``EnvironmentValues`` structure
+    /// to get and set a value for that key.
     public subscript<K>(key: K.Type) -> K.Value where K : EnvironmentKey {
         get {
             guard let value = everyValue[ObjectIdentifier(key)] as? K.Value else { return key.defaultValue }

--- a/Sources/Ignite/Publishing/Environment/EnvironmentValues.swift
+++ b/Sources/Ignite/Publishing/Environment/EnvironmentValues.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public struct EnvironmentValues {
+    static public var shared = EnvironmentValues()
     private var everyValue: [ObjectIdentifier: Any] = [:]
 
     public init() {}

--- a/Sources/Ignite/Publishing/Environment/EnvironmentValues.swift
+++ b/Sources/Ignite/Publishing/Environment/EnvironmentValues.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public struct EnvironmentValues {
-    static public var shared = EnvironmentValues()
+    static var shared = EnvironmentValues()
     private var everyValue: [ObjectIdentifier: Any] = [:]
 
     public init() {}
@@ -18,6 +18,6 @@ public struct EnvironmentValues {
             guard let value = everyValue[ObjectIdentifier(key)] as? K.Value else { return key.defaultValue }
             return value
         }
-        set {  everyValue[ObjectIdentifier(key)] = newValue }
+        set { everyValue[ObjectIdentifier(key)] = newValue }
     }
 }

--- a/Sources/Ignite/Publishing/Environment/Keys/PublishingContextKey.swift
+++ b/Sources/Ignite/Publishing/Environment/Keys/PublishingContextKey.swift
@@ -18,7 +18,7 @@ extension EnvironmentValues {
     }
 }
 
-extension  PublishingContext {
+fileprivate extension  PublishingContext {
     struct EmptySite: Site {
         var name = ""
         var titleSuffix = ""
@@ -39,5 +39,5 @@ extension  PublishingContext {
         }
     }
 
-    fileprivate static var empty = try! PublishingContext(for: EmptySite(), from: "")
+    static var empty = try! PublishingContext(for: EmptySite(), from: "")
 }

--- a/Sources/Ignite/Publishing/Environment/Keys/PublishingContextKey.swift
+++ b/Sources/Ignite/Publishing/Environment/Keys/PublishingContextKey.swift
@@ -1,0 +1,19 @@
+//
+// PublishingContextKey.swift
+// Ignite
+// https://www.github.com/piotrekjeremicz/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+
+struct PublishingContextKey: EnvironmentKey {
+    static let defaultValue = PublishingContext.empty
+}
+
+extension EnvironmentValues {
+    public var context: PublishingContext {
+        get { self[PublishingContextKey.self] }
+        set { self[PublishingContextKey.self] = newValue }
+    }
+}

--- a/Sources/Ignite/Publishing/Environment/Keys/PublishingContextKey.swift
+++ b/Sources/Ignite/Publishing/Environment/Keys/PublishingContextKey.swift
@@ -29,7 +29,7 @@ fileprivate extension  PublishingContext {
     struct EmptySite: Site {
         var name = ""
         var titleSuffix = ""
-        var url = URL("")
+        var url = URL("https://example.com")
 
         var builtInIconsEnabled = false
         var syntaxHighlighters: [SyntaxHighlighter] = []
@@ -46,5 +46,5 @@ fileprivate extension  PublishingContext {
         }
     }
 
-    static var empty = try! PublishingContext(for: EmptySite(), from: "")
+    static var empty = try! PublishingContext(for: EmptySite(), rootURL: URL.documentsDirectory)
 }

--- a/Sources/Ignite/Publishing/Environment/Keys/PublishingContextKey.swift
+++ b/Sources/Ignite/Publishing/Environment/Keys/PublishingContextKey.swift
@@ -17,3 +17,27 @@ extension EnvironmentValues {
         set { self[PublishingContextKey.self] = newValue }
     }
 }
+
+extension  PublishingContext {
+    struct EmptySite: Site {
+        var name = ""
+        var titleSuffix = ""
+        var url = URL("http://example.com")
+
+        var builtInIconsEnabled = false
+        var syntaxHighlighters: [SyntaxHighlighter] = []
+
+        var homePage = EmptyPage()
+        var theme = EmptyTheme()
+    }
+
+    struct EmptyPage: StaticPage {
+        var title: String = ""
+
+        func body(context: PublishingContext) -> [any BlockElement] {
+            Text("")
+        }
+    }
+
+    fileprivate static var empty = try! PublishingContext(for: EmptySite(), from: "")
+}

--- a/Sources/Ignite/Publishing/Environment/Keys/PublishingContextKey.swift
+++ b/Sources/Ignite/Publishing/Environment/Keys/PublishingContextKey.swift
@@ -7,22 +7,29 @@
 
 import Foundation
 
+/// A key for accessing the `PublishingContext` value.
 struct PublishingContextKey: EnvironmentKey {
+    /// The default value for `PublishingContext` it is `.empty` representation of itself.
     static let defaultValue = PublishingContext.empty
 }
 
+/// Association of the custom key with its value.
 extension EnvironmentValues {
+    /// The `PublishingContext` environment value associated with a `PublishingContextKey`.
     public var context: PublishingContext {
         get { self[PublishingContextKey.self] }
         set { self[PublishingContextKey.self] = newValue }
     }
 }
 
+/// **This is temporary solution**
+/// `PublishingContext` needs an empty representation of itself. It is provided by creating `EmptySite` structure.
+/// Those structures should not be used anywhere else.
 fileprivate extension  PublishingContext {
     struct EmptySite: Site {
         var name = ""
         var titleSuffix = ""
-        var url = URL("http://example.com")
+        var url = URL("")
 
         var builtInIconsEnabled = false
         var syntaxHighlighters: [SyntaxHighlighter] = []

--- a/Tests/IgniteTests/Environment/EnvironmentTests.swift
+++ b/Tests/IgniteTests/Environment/EnvironmentTests.swift
@@ -1,0 +1,32 @@
+//
+// EnvironmentTests.swift
+// Ignite
+// https://www.github.com/piotrekjeremicz/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+
+import XCTest
+@testable import Ignite
+
+/// Specific test case that for `@Environment` tests that sets up an example publishing context for testing purposes.
+class EnvironmentTests: XCTestCase {
+    func test_environment_values() {
+        /// A publishing context with sample values.
+        let publishingContext = try! PublishingContext(
+            for: TestSite(
+                homePage: EnvironmentTestPage()
+            ),
+            rootURL: URL.documentsDirectory
+        )
+
+        /// Simulate `PublishingContext` injection as is done during the publication process.
+        EnvironmentValues.shared[keyPath: \.context] = publishingContext
+
+        /// Get **HomePage** render output.
+        let output = publishingContext.site.homePage.body(context: publishingContext).render(context: publishingContext)
+
+        XCTAssertEqual(output, "<p>My Test Site</p>")
+    }
+}

--- a/Tests/IgniteTests/IgniteTests.swift
+++ b/Tests/IgniteTests/IgniteTests.swift
@@ -1,9 +1,13 @@
 import XCTest
 @testable import Ignite
 
-
 /// A base class that sets up an example publishing context for testing purposes.
 class ElementTest: XCTestCase {
     /// A publishing context with sample values.
-    let publishingContext = try! PublishingContext(for: TestSite(), rootURL: URL.documentsDirectory)
+    let publishingContext = try! PublishingContext(
+        for: TestSite(
+            homePage: TestPage()
+        ),
+        rootURL: URL.documentsDirectory
+    )
 }

--- a/Tests/IgniteTests/TestSite.swift
+++ b/Tests/IgniteTests/TestSite.swift
@@ -9,7 +9,7 @@ import Foundation
 import Ignite
 
 /// An example site used in tests.
-struct TestSite: Site {
+struct TestSite<HomePageType>: Site where HomePageType: StaticPage {
     var name = "My Test Site"
     var titleSuffix = " - My Test Site"
     var url = URL("https://www.yoursite.com")
@@ -17,8 +17,12 @@ struct TestSite: Site {
     var builtInIconsEnabled = true
     var syntaxHighlighters = [SyntaxHighlighter.objectiveC]
 
-    var homePage = TestPage()
     var theme = EmptyTheme()
+    var homePage: HomePageType
+    
+    init(homePage: HomePageType) {
+        self.homePage = homePage
+    }
 }
 
 /// An example page  used in tests.
@@ -27,5 +31,15 @@ struct TestPage: StaticPage {
 
     func body(context: PublishingContext) -> [any BlockElement] {
         Text("Example text")
+    }
+}
+
+/// An example page with `@Environment` context used in tests.
+struct EnvironmentTestPage: StaticPage {
+    var title: String = "Environment Test"
+    @Environment(\.context) private var environmentContext
+
+    func body(context: PublishingContext) -> [any BlockElement] {
+        Text(environmentContext.site.name)
     }
 }


### PR DESCRIPTION
This Pull Request is adding `@Environment` property wrapper as a global environment injection.

`@Environment` was created based on the same equivalent from SwiftUI. It allows you to get a global variable, but the setter is not available outside the Ignite package. The first global variable implemented within this feature is `PublishingContext`.


You can use it as follows:
```swift
struct HomePage: StaticPage {
    var title: String = "Home Page"
    
    @Environment(\.context) private var environmentContext

    func body(context: PublishingContext) -> [any BlockElement] {
        Text(environmentContext.site.name)
    }
}
```

There are many global variables that could be added. It is simple, as in the original SwiftUI implementation. To add a new environment variable, first create a new `EnvironmentKey` and extend `EnvironmentValues` with the declared getter and setter.
```swift
struct PublishingContextKey: EnvironmentKey {
    static let defaultValue = PublishingContext.empty
}

extension EnvironmentValues {
    public var context: PublishingContext {
        get { self[PublishingContextKey.self] }
        set { self[PublishingContextKey.self] = newValue }
    }
}
```

`EnvironmentValues` is stored in the memory once, as the singleton. This is a field for discussion if it is a good solution. Maybe a global variable could be better. In the case of the Ignite implementation, we have a static code generator. Memory optimization is primarily not our first priority.

To set a value in a store, you can use the `shared` variable, as is presented below. 
```swift
EnvironmentValues.shared[PublishingContextKey.self] = context
```

My goal is to replace the creational function `func body(context: PublishingContext) -> [any BlockElement] {}` with a opaque type `var body: some HTML {}` as it stands in SwiftUI Views.