### PR TITLE
Adds Spotify to Embed

### DIFF
--- a/Sources/Ignite/Elements/Embed.swift
+++ b/Sources/Ignite/Elements/Embed.swift
@@ -76,10 +76,10 @@ public struct Embed: BlockElement, LazyLoadable {
     /// Creates a new `Embed` instance from the title and Spotify ID provided.
     /// - Parameters:
     ///   - title: A title suitable for screen readers.
-    ///   - url: The YouTube ID to use.
+    ///   - url: The Spotify ID to use.
     ///   - type: The SpotifyContentType to use.
     ///   - theme: Either 0 or 1, each representing one of the two theme options offered by Spotify, which can be found in the code they provide.
-    public init(spotifyID: String, title: String, type: SpotifyContentType = .track, theme: Int) {
+    public init(spotifyID: String, title: String, type: SpotifyContentType = .track, theme: Int = 0) {
         if let test = URL(string: "https://open.spotify.com/embed/\(type.rawValue)/\(spotifyID)?utm_source=generator&theme=\(theme)") {
             self.url = test.absoluteString
             self.title = title

--- a/Sources/Ignite/Elements/Embed.swift
+++ b/Sources/Ignite/Elements/Embed.swift
@@ -64,6 +64,29 @@ public struct Embed: BlockElement, LazyLoadable {
             fatalError("Failed to create YouTube URL from video ID: \(youTubeID).")
         }
     }
+    
+    /// Controls what happens when a section is opened.
+    public enum SpotifyContentType: String {
+        /// Creates interactive item for a single Spotify track
+        case track
+        /// Creates interactive  item for a Spotify playlist
+        case playlist
+    }
+    
+    /// Creates a new `Embed` instance from the title and Spotify ID provided.
+    /// - Parameters:
+    ///   - title: A title suitable for screen readers.
+    ///   - url: The YouTube ID to use.
+    ///   - type: The SpotifyContentType to use.
+    ///   - theme: Either 0 or 1, each representing one of the two theme options offered by Spotify, which can be found in the code they provide.
+    public init(spotifyID: String, title: String, type: SpotifyContentType = .track, theme: Int) {
+        if let test = URL(string: "https://open.spotify.com/embed/\(type.rawValue)/\(spotifyID)?utm_source=generator&theme=\(theme)") {
+            self.url = test.absoluteString
+            self.title = title
+        } else {
+            fatalError("Failed to create Spotify URL from ID: \(spotifyID).")
+        }
+    }
 
     /// Renders this element using publishing context passed in.
     /// - Parameter context: The current publishing context.


### PR DESCRIPTION
## Proposal
- Add Spotify as an Embed option
- Through the Share option on a track or playlist, Spotify provides a block of code that can be used to embed an audio player into a web page.

<img width="662" alt="Screenshot 2024-04-24 at 10 31 42 AM" src="https://github.com/twostraws/Ignite/assets/78987924/0f337171-d5d1-4081-9b03-5dd79662ba45">

## Progress
For [my own website](https://www.jessielinden.com/music), I customized what they provided by taking the following steps:
- first I combined what the various `Embed` inits do (set `url` and `title`) and what its `render` function does into a function `embed` that returns a string
```
enum SpotifyContentType: String {
        case track, playlist
    }

func embed(spotifyID: String, title: String, height: String = "520", type: SpotifyContentType = .track) -> String {
        if let test = URL(string: "https://open.spotify.com/embed/\(type.rawValue)/\(spotifyID)?utm_source=generator&theme=0") {
            let url = test.absoluteString
            let allowPermissions = "autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
            return #"<iframe src="\#(url)" title="\#(title)" width="100%" height="\#(height)" allowfullscreen="" allow="\#(allowPermissions)"></iframe>"#
        } else {
            fatalError("Failed to create Spotify URL from ID: \(spotifyID).")
        }
    }
```
- I edited out parts of their code that didn't match what was in `Embed` with the hope I could at some point propose adding this in without having to touch its render code, because it seems that we're getting things through the 'embed' part of the Spotify URL (ex. `border-radius: 12px`), so now the only parameters that don't match are **width and height**
- I called my `embed` function inside a `Text` and voila

## Issues 
- Why do I need to specify the width and height? 
In a browser, [the URL by itself renders a player that takes up the whole screen](https://open.spotify.com/embed/album/6BzxX6zkDsYKFJ04ziU5xQ?utm_source=generator&theme=0). But on my page, the default size is a small box.
I preferred my version to be as tall as my track count (found through trial and error) and as wide as possible, and I could see others wanting other customizations.
- I tried forking the repo and hoped I could incorporate this into `Embed`. I got as far as the code in this PR, which does not have customized dimensions. I had hoped that the desired dimensions could be achieved via the `style` and `frame` modifiers, but that did not work. I am aware that an aspect ratio must be set for `Embed` instances, so I'm interested to know if this incorporation is even possible.

Making this website is my first encounter with html or css, so I may just be missing something simple.
In any case, if this is interesting to add to Ignite, I'd love some help in making it work! And if not, I totally understand