### PR TITLE
Added 'text-decoration': .none, .through and .underline for text

### DIFF
--- a/Sources/Ignite/Modifiers/TextDecoration.swift
+++ b/Sources/Ignite/Modifiers/TextDecoration.swift
@@ -1,0 +1,24 @@
+//
+// TextDecoration.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+
+/// Property sets the appearance of decorative lines on text.
+public enum TextDecoration: String {
+    case none = "text-decoration-none"
+    case through = "text-decoration-line-through"
+    case underline = "text-decoration-underline"
+}
+
+extension PageElement {
+    /// Applies a text decoration style to the current element.
+    /// - Parameter style: The style to apply, specified as a `TextDecoration` case.
+    /// - Returns: The current element with the updated text decoration style applied.
+    public func textDecoration(_ style: TextDecoration) -> Self {
+        self.class(style.rawValue)
+    }
+}


### PR DESCRIPTION
I would like to add the ability to change the text formatting using the `textDecoration` modifier, which has the values: 
* `.underline` 
* `.through`
* `.none`
<img width="697" alt="Screenshot 2024-04-24 at 5 45 04 PM" src="https://github.com/twostraws/Ignite/assets/5351622/f271e265-8be7-400f-8aaa-1cb30e35f2ac">
<br><br>
The `.none` value can also be used for links if you want to place a link without the underscore