### PR TITLE
Enhancing `Card`

### DIFF
--- a/Sources/Ignite/Elements/Card.swift
+++ b/Sources/Ignite/Elements/Card.swift
@@ -22,24 +22,31 @@ public struct Card: BlockElement {
     }
 
     /// Where to position the content of the card relative to it image.
-    public enum ContentPosition: String, CaseIterable {
+    public enum ContentPosition: CaseIterable {
         /// Positions content below the image.
-        case bottom = "card-img-top"
+        case bottom
 
         /// Positions content above the image.
-        case top = "card-img-bottom"
+        case top
 
         /// Positions content over the image.
-        case overlay = "card-img-overlay"
+        case overlay
 
         public static let `default` = Self.bottom
 
         var imageClass: String {
-            self == .overlay ? "card-img" : rawValue
+            switch self {
+            case .bottom:
+                "card-img-bottom"
+            case .top:
+                "card-img-top"
+            case .overlay:
+                "card-img"
+            }
         }
 
         var bodyClass: String {
-            self == .overlay ? rawValue : "card-body"
+            self == .overlay ? "card-img-overlay" : "card-body"
         }
     }
 

--- a/Sources/Ignite/Elements/Card.swift
+++ b/Sources/Ignite/Elements/Card.swift
@@ -24,10 +24,23 @@ public struct Card: BlockElement {
     /// Where to position the content of the card relative to it image.
     public enum ContentPosition: String, CaseIterable {
         /// Positions content below the image.
-        case `default` = "card-body"
+        case bottom = "card-img-top"
 
         /// Positions content above the image.
+        case top = "card-img-bottom"
+
+        /// Positions content over the image.
         case overlay = "card-img-overlay"
+
+        public static let `default` = Self.bottom
+
+        var imageClass: String {
+            self == .overlay ? "card-img" : rawValue
+        }
+
+        var bodyClass: String {
+            self == .overlay ? rawValue : "card-body"
+        }
     }
 
     /// The standard set of control attributes for HTML elements.
@@ -117,14 +130,14 @@ public struct Card: BlockElement {
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
         Group {
-            if let image {
+            if let image, contentPosition != .top {
                 if imageOpacity != 1 {
                     image
-                        .class("card-img-top")
+                        .class(contentPosition.imageClass)
                         .style("opacity: \(imageOpacity)")
                 } else {
                     image
-                        .class("card-img-top")
+                        .class(contentPosition.imageClass)
                 }
             }
 
@@ -156,7 +169,18 @@ public struct Card: BlockElement {
                     }
                 }
             }
-            .class(contentPosition.rawValue)
+            .class(contentPosition.bodyClass)
+
+            if let image, contentPosition == .top {
+                if imageOpacity != 1 {
+                    image
+                        .class(contentPosition.imageClass)
+                        .style("opacity: \(imageOpacity)")
+                } else {
+                    image
+                        .class(contentPosition.imageClass)
+                }
+            }
 
             if footer.isEmpty == false {
                 Group {

--- a/Sources/Ignite/Elements/Card.swift
+++ b/Sources/Ignite/Elements/Card.swift
@@ -149,6 +149,8 @@ public struct Card: BlockElement {
                         }
                     case is Link:
                         item.class("card-link")
+                    case is Image:
+                        item.class("card-img")
                     default:
                         item
                     }


### PR DESCRIPTION
Inspired by your HWS+ session about Ignite today, I was looking more into how `Card` is working and how the generated HTML relates to the [Bootstrap documentation](https://getbootstrap.com/docs/5.3/components/card/#image-caps).
I've seen that it would be possible to place the image above and below the content text and that Bootstrap is "capping" the edges of the image accordingly. The current version of `ContentPosition` does only support placing the content below the image (=first image, then content) and hardcoded the CSS classes accordingly to "card-img-top".

I've enhanced this by adding additional options. 
Further I added a fix to allow the image being placed into content of a `Card`: The image has to get the "card-img" CSS class for proper sizing.

I'm not yet fully convinced by the current solution. Do you think `ContentPosition` enum needs more adjustments?
Is `ContentPosition` the correct wording? Wouldn't `ImagePosition` `.top`, `.bottom` and `.background` be more appropriate?

<img width="834" alt="Screenshot showing all 4 variations" src="https://github.com/twostraws/Ignite/assets/25307503/543af1a6-f183-4fd3-b563-3160174b5fc6">
