### PR TITLE
Added path to FeedConfiguration to make RSS endpoint configurable

### DIFF
--- a/Sources/Ignite/Components/FeedLink.swift
+++ b/Sources/Ignite/Components/FeedLink.swift
@@ -20,7 +20,7 @@ struct FeedLink: Component {
                         .margin(.trailing, 10)
                 }
 
-                Link("RSS Feed", target: "/feed.rss")
+                Link("RSS Feed", target: context.site.feedConfiguration.path)
             }
             .horizontalAlignment(.center)
         }

--- a/Sources/Ignite/Framework/FeedConfiguration.swift
+++ b/Sources/Ignite/Framework/FeedConfiguration.swift
@@ -55,23 +55,28 @@ public struct FeedConfiguration {
     /// How many items of contentshould be returned.
     var contentCount: Int
 
+    /// The path to where the generated rss xml file for the feed endpoint should be.
+    var path: String
+
     /// An optional image used to customize your feed's appearance in
     /// feed readers.
     var image: FeedImage?
 
-    /// A safe default feed configuration: 20 items, description only.
-    static let `default` = FeedConfiguration(mode: .descriptionOnly, contentCount: 20)
+    /// A safe default feed configuration: 20 items, description only, path at /feed.rss.
+    static let `default` = FeedConfiguration(mode: .descriptionOnly, contentCount: 20, path: "/feed.rss")
 
     /// Creates a custom feed configuration from the options provided.
     /// - Parameters:
     ///   - mode: Whether to descriptions or full article text, or to disable the
     ///   feed entirely.
     ///   - contentCount: How many pieces of content to return.
+    ///   - path: The path where the RSS feed should be accessible, default to /feed.rss
     ///   - image: An optional image used to customize your feed's
     ///   appearance in feed readers.
-    public init(mode: ContentMode, contentCount: Int, image: FeedImage? = nil) {
+    public init(mode: ContentMode, contentCount: Int, path: String = "/feed.rss", image: FeedImage? = nil) {
         self.mode = mode
         self.contentCount = contentCount
+        self.path = path
         self.image = image
     }
 }

--- a/Sources/Ignite/Publishing/FeedGenerator.swift
+++ b/Sources/Ignite/Publishing/FeedGenerator.swift
@@ -55,7 +55,7 @@ struct FeedGenerator {
         <title>\(site.name)</title>\
         <description>\(site.description ?? "")</description>\
         <link>\(site.url.absoluteString)</link>\
-        <atom:link href="\(site.url.absoluteString)/feed.rss" rel="self" type="application/rss+xml" />\
+        <atom:link href="\(site.url.appending(path: site.feedConfiguration.path).absoluteString)" rel="self" type="application/rss+xml" />\
         <language>\(site.language.rawValue)</language>\
         <generator>\(Ignite.version)</generator>
         """

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -373,7 +373,7 @@ public class PublishingContext {
         let result = generator.generateFeed()
 
         do {
-            let destinationURL = buildDirectory.appending(path: "feed.rss")
+            let destinationURL = buildDirectory.appending(path: site.feedConfiguration.path)
             try result.write(to: destinationURL, atomically: true, encoding: .utf8)
         } catch {
             throw PublishingError.failedToWriteFeed


### PR DESCRIPTION
When upgrading a website to use Ignite, it helps to keep the same RSS feed URL as before.
The current implementation has hardcoded the endpoint to `{site_url}/feed.rss`.

This PR adds a `var path: String` to the `FeedConfiguration` to make this endpoint configurable.

It also works with paths like `path: "blog/rss.xml"`