### PR TITLE
Fix the reversed `imageClass` for `ContentPosition`

### DIFF
--- a/Sources/Ignite/Elements/Card.swift
+++ b/Sources/Ignite/Elements/Card.swift
@@ -40,9 +40,9 @@ public struct Card: BlockElement {
         var imageClass: String {
             switch self {
             case .bottom:
-                "card-img-bottom"
-            case .top:
                 "card-img-top"
+            case .top:
+                "card-img-bottom"
             case .overlay, .overlayCenter:
                 "card-img"
             }


### PR DESCRIPTION
While writing the documentation on https://github.com/twostraws/IgniteSamples/pull/8 I found this bug (probably caused by my refactoring): I've flipped the image classes in `ContentPosition.imageClass`.

This bug is showing as incorrectly "capped" corners:
![image](https://github.com/twostraws/Ignite/assets/25307503/b2943463-43c7-494d-bc7f-6e20c1113674)

This additional change is fixing this.