### PR TITLE
Allow to specify alignment for Card `overlay`

### DIFF
--- a/Sources/Ignite/Elements/Card.swift
+++ b/Sources/Ignite/Elements/Card.swift
@@ -40,6 +40,7 @@ public struct Card: BlockElement {
         public static let `default` = Self.bottom
         public static let overlay = Self.overlay(alignment: .topLeading)
 
+        // MARK: Helpers for `render`
         var imageClass: String {
             switch self {
             case .bottom:
@@ -51,12 +52,21 @@ public struct Card: BlockElement {
             }
         }
 
-        var bodyClass: String {
+        var bodyClasses: [String] {
             switch self {
-            case .overlay:
-                "card-img-overlay"
+            case .overlay(let alignment):
+                ["card-img-overlay", alignment.textAlignment.rawValue, alignment.verticalAlignment.rawValue]
             default:
-                "card-body"
+                ["card-body"]
+            }
+        }
+
+        var addImageFirst: Bool {
+            switch self {
+            case .bottom, .overlay:
+                true
+            case .top:
+                false
             }
         }
     }
@@ -195,22 +205,8 @@ public struct Card: BlockElement {
     /// - Parameter context: The current publishing context.
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
-        var bodyClasses = [contentPosition.bodyClass]
-        var addImageFirst: Bool
-
-        switch contentPosition {
-        case .bottom:
-            addImageFirst = true
-        case .top:
-            addImageFirst = false
-        case .overlay(let alignment):
-            addImageFirst = true
-            bodyClasses.append(alignment.textAlignment.rawValue)
-            bodyClasses.append(alignment.verticalAlignment.rawValue)
-        }
-
-        return Group {
-            if let image, addImageFirst {
+        Group {
+            if let image, contentPosition.addImageFirst {
                 if imageOpacity != 1 {
                     image
                         .class(contentPosition.imageClass)
@@ -249,9 +245,9 @@ public struct Card: BlockElement {
                     }
                 }
             }
-            .class(bodyClasses)
+            .class(contentPosition.bodyClasses)
 
-            if let image, !addImageFirst {
+            if let image, !contentPosition.addImageFirst {
                 if imageOpacity != 1 {
                     image
                         .class(contentPosition.imageClass)

--- a/Sources/Ignite/Elements/Card.swift
+++ b/Sources/Ignite/Elements/Card.swift
@@ -58,6 +58,54 @@ public struct Card: BlockElement {
         }
     }
 
+    enum TextAlignment: String, CaseIterable {
+        case start = "text-start"
+        case center = "text-center"
+        case end = "text-end"
+    }
+
+    enum VerticalAlignment: String, CaseIterable {
+        case start = "align-content-start"
+        case center = "align-content-center"
+        case end = "align-content-end"
+    }
+
+    public enum ContentAlignment: CaseIterable {
+        case topLeading
+        case top
+        case topTrailing
+        case leading
+        case center
+        case trailing
+        case bottomLeading
+        case bottom
+        case bottomTrailing
+
+        var textAlignment: TextAlignment {
+            switch self {
+            case .topLeading, .leading, .bottomLeading:
+                    .start
+            case .top, .center, .bottom:
+                    .center
+            case .topTrailing, .trailing, .bottomTrailing:
+                    .end
+            }
+        }
+
+        var verticalAlignment: VerticalAlignment {
+            switch self {
+            case .topLeading, .top, .topTrailing:
+                    .start
+            case .leading, .center, .trailing:
+                    .center
+            case .bottomLeading, .bottom, .bottomTrailing:
+                    .end
+            }
+        }
+
+        public static let `default` = Self.topLeading
+    }
+
     /// The standard set of control attributes for HTML elements.
     public var attributes = CoreAttributes()
 
@@ -68,6 +116,7 @@ public struct Card: BlockElement {
     var style = CardStyle.default
 
     var contentPosition = ContentPosition.default
+    var contentAlignment = ContentAlignment.default
     var imageOpacity = 1.0
 
     var image: Image?
@@ -130,6 +179,15 @@ public struct Card: BlockElement {
         return copy
     }
 
+    /// Adjusts the position of this card's content relative to its image.
+    /// - Parameter newPosition: The new content positio for this card.
+    /// - Returns: A new `Card` instance with the updated content position.
+    public func contentAlignment(_ newAlignment: ContentAlignment) -> Self {
+        var copy = self
+        copy.contentAlignment = newAlignment
+        return copy
+    }
+
     /// Adjusts the opacity of the image for this card. Use values
     /// lower than 1.0 to progressively dim the image.
     /// - Parameter opacity: The new opacity for this card.
@@ -153,6 +211,11 @@ public struct Card: BlockElement {
             bodyClasses.append("align-content-center")
             width = "100%"
             height = "100%"
+        } else if contentPosition == .overlay {
+            if contentAlignment != .default {
+                bodyClasses.append(contentAlignment.textAlignment.rawValue)
+                bodyClasses.append(contentAlignment.verticalAlignment.rawValue)
+            }
         }
 
         return Group {

--- a/Sources/Ignite/Elements/Card.swift
+++ b/Sources/Ignite/Elements/Card.swift
@@ -34,7 +34,7 @@ public struct Card: BlockElement {
         case top
 
         /// Positions content over the image.
-        case overlay(alignment: ContentAlignment = .center)
+        case overlay(alignment: ContentAlignment)
 
         // Static entries for backward compatibilty
         public static let `default` = Self.bottom

--- a/Sources/Ignite/Elements/Card.swift
+++ b/Sources/Ignite/Elements/Card.swift
@@ -58,20 +58,16 @@ public struct Card: BlockElement {
         }
     }
 
-    enum ContentJustify: String, CaseIterable {
-        case start = "justify-content-start"
-        case center = "justify-content-center"
-        case end = "justify-content-end"
-
-        // ... there would be more options in Bootstrap
+    enum TextAlignment: String, CaseIterable {
+        case start = "text-start"
+        case center = "text-center"
+        case end = "text-end"
     }
 
-    enum ItemAlignment: String, CaseIterable {
-        case start = "align-items-start"
-        case center = "align-items-center"
-        case end = "align-items-end"
-
-        // ... there would be more options in Bootstrap
+    enum VerticalAlignment: String, CaseIterable {
+        case start = "align-content-start"
+        case center = "align-content-center"
+        case end = "align-content-end"
     }
 
     public enum ContentAlignment: CaseIterable {
@@ -85,7 +81,7 @@ public struct Card: BlockElement {
         case bottom
         case bottomTrailing
 
-        var contentJustify: ContentJustify {
+        var textAlignment: TextAlignment {
             switch self {
             case .topLeading, .leading, .bottomLeading:
                     .start
@@ -96,7 +92,7 @@ public struct Card: BlockElement {
             }
         }
 
-        var itemAlignment: ItemAlignment {
+        var verticalAlignment: VerticalAlignment {
             switch self {
             case .topLeading, .top, .topTrailing:
                     .start
@@ -216,9 +212,10 @@ public struct Card: BlockElement {
             width = "100%"
             height = "100%"
         } else if contentPosition == .overlay {
-            bodyClasses.append(contentAlignment.contentJustify.rawValue)
-            bodyClasses.append(contentAlignment.itemAlignment.rawValue)
-            bodyClasses.append("d-flex")
+            if contentAlignment != .default {
+                bodyClasses.append(contentAlignment.textAlignment.rawValue)
+                bodyClasses.append(contentAlignment.verticalAlignment.rawValue)
+            }
         }
 
         return Group {

--- a/Sources/Ignite/Elements/Card.swift
+++ b/Sources/Ignite/Elements/Card.swift
@@ -58,16 +58,20 @@ public struct Card: BlockElement {
         }
     }
 
-    enum TextAlignment: String, CaseIterable {
-        case start = "text-start"
-        case center = "text-center"
-        case end = "text-end"
+    enum ContentJustify: String, CaseIterable {
+        case start = "justify-content-start"
+        case center = "justify-content-center"
+        case end = "justify-content-end"
+
+        // ... there would be more options in Bootstrap
     }
 
-    enum VerticalAlignment: String, CaseIterable {
-        case start = "align-content-start"
-        case center = "align-content-center"
-        case end = "align-content-end"
+    enum ItemAlignment: String, CaseIterable {
+        case start = "align-items-start"
+        case center = "align-items-center"
+        case end = "align-items-end"
+
+        // ... there would be more options in Bootstrap
     }
 
     public enum ContentAlignment: CaseIterable {
@@ -81,7 +85,7 @@ public struct Card: BlockElement {
         case bottom
         case bottomTrailing
 
-        var textAlignment: TextAlignment {
+        var contentJustify: ContentJustify {
             switch self {
             case .topLeading, .leading, .bottomLeading:
                     .start
@@ -92,7 +96,7 @@ public struct Card: BlockElement {
             }
         }
 
-        var verticalAlignment: VerticalAlignment {
+        var itemAlignment: ItemAlignment {
             switch self {
             case .topLeading, .top, .topTrailing:
                     .start
@@ -212,10 +216,9 @@ public struct Card: BlockElement {
             width = "100%"
             height = "100%"
         } else if contentPosition == .overlay {
-            if contentAlignment != .default {
-                bodyClasses.append(contentAlignment.textAlignment.rawValue)
-                bodyClasses.append(contentAlignment.verticalAlignment.rawValue)
-            }
+            bodyClasses.append(contentAlignment.contentJustify.rawValue)
+            bodyClasses.append(contentAlignment.itemAlignment.rawValue)
+            bodyClasses.append("d-flex")
         }
 
         return Group {


### PR DESCRIPTION
This PR enhances `ContentPosition.overlay` to take an alignment argument: `.overlay(alignment:)`
The alignment is defined as

```swift
enum ContentAlignment: CaseIterable {
    case topLeading
    case top
    case topTrailing
    case leading
    case center
    case trailing
    case bottomLeading
    case bottom
    case bottomTrailing
}
```

The implementation uses the Bootstrap "text alignment" and "vertical alignment" classes.

The following example usage shows all nine cases:

```swift
Text(markdown: """
To control the position of the overlay you can specify an alignment using `.overlay(alignment:)`
with one of the following options:
""")

Section {
    for alignment in Card.ContentAlignment.allCases {
        let alignmentName = String(describing: alignment)
        Card(imageName: "/images/photos/dishwasher.jpg") {
            Text(markdown: "`.\(alignmentName)`")
                .foregroundStyle(.white)
                .backgroundColor(.lightGray)

            Link("Back to the homepage", target: "/")
                .linkStyle(.button)
        }
        .contentPosition(.overlay(alignment: alignment))
        .imageOpacity(0.5)
    }
}
.margin(.top, .large)
.columns(3)
```

<img width="1035" alt="All-Alignment-Cases" src="https://github.com/twostraws/Ignite/assets/25307503/4a2367b3-5eae-414a-8416-a51d6487d2de">

