### PR TITLE
prepare for "non root" sites ..

### DIFF
--- a/Sources/Ignite/Framework/Site.swift
+++ b/Sources/Ignite/Framework/Site.swift
@@ -159,6 +159,11 @@ extension Site {
     ///   The default is "Build".
     public func publish(from file: StaticString = #file, buildDirectoryPath: String = "Build") async throws {
         let context = try PublishingContext(for: self, from: file, buildDirectoryPath: buildDirectoryPath)
+
+        if buildDirectoryPath.contains("/") {
+            context.addWarning("in \"\(#function)\" buildDirectoryPath is heirarchical (\"\(buildDirectoryPath)\")")
+        }
+
         try await context.publish()
 
         if context.warnings.isEmpty == false {

--- a/Sources/Ignite/Framework/Site.swift
+++ b/Sources/Ignite/Framework/Site.swift
@@ -159,11 +159,6 @@ extension Site {
     ///   The default is "Build".
     public func publish(from file: StaticString = #file, buildDirectoryPath: String = "Build") async throws {
         let context = try PublishingContext(for: self, from: file, buildDirectoryPath: buildDirectoryPath)
-
-        if buildDirectoryPath.contains("/") {
-            context.addWarning("in \"\(#function)\" buildDirectoryPath is heirarchical (\"\(buildDirectoryPath)\")")
-        }
-
         try await context.publish()
 
         if context.warnings.isEmpty == false {

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -179,8 +179,7 @@ public class PublishingContext {
     func copyResources() throws {
         let assets = try FileManager.default.contentsOfDirectory(
             at: assetsDirectory,
-            includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
+            includingPropertiesForKeys: nil
         )
 
         for asset in assets {

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -167,7 +167,7 @@ public class PublishingContext {
         }
 
         do {
-            try FileManager.default.createDirectory(at: buildDirectory, withIntermediateDirectories: false)
+            try FileManager.default.createDirectory(at: buildDirectory, withIntermediateDirectories: true)
         } catch {
             throw PublishingError.failedToCreateBuildDirectory(buildDirectory)
         }
@@ -179,7 +179,8 @@ public class PublishingContext {
     func copyResources() throws {
         let assets = try FileManager.default.contentsOfDirectory(
             at: assetsDirectory,
-            includingPropertiesForKeys: nil
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
         )
 
         for asset in assets {


### PR DESCRIPTION
In preparation for allowing Ignite to construct "non root" sites (ie: `https://site.com/NONROOT/index.html`), some protection and adjustments:

* issue a warning if there's a `\` in `buildDirectoryPath`
(the warning is emitted in an Xcode build but not a CLI build)
* allow the site directory to be created
(change `withIntermediateDirectories` to `true` in `PublishingContext`)
* don't copy hidden (".") files into site
(I don't think web sites use hidden files, certainly not `.DS_Store` !)

_My first PR -- please suggest any improvements_