### PR TITLE
Add attributes to the script element

### DIFF
--- a/Sources/Ignite/Elements/Script.swift
+++ b/Sources/Ignite/Elements/Script.swift
@@ -44,9 +44,9 @@ public struct Script: BlockElement & HeadElement {
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
         if let file {
-            return "<script src=\"\(file)\"></script>"
+            return "<script\(attributes.description) src=\"\(file)\"></script>"
         } else if let code {
-            return "<script>\(code)</script>"
+            return "<script\(attributes.description)>\(code)</script>"
         } else {
             context.addWarning("""
             Creating a script with no source or code should not be possible. \

--- a/Tests/IgniteTests/Elements/Script.swift
+++ b/Tests/IgniteTests/Elements/Script.swift
@@ -1,0 +1,35 @@
+//
+// Script.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+import XCTest
+@testable import Ignite
+
+/// Tests for the `Script` element.
+final class ScriptTests: ElementTest {
+    func test_code() {
+        let element = Script(code: "javascript code")
+        let output = element.render(context: publishingContext)
+
+        XCTAssertEqual(output, "<script>javascript code</script>")
+    }
+
+    func test_file() {
+        let element = Script(file: "/code.js")
+        let output = element.render(context: publishingContext)
+
+        XCTAssertEqual(output, "<script src=\"/code.js\"></script>")
+    }
+
+    func test_attributes() {
+        let element = Script(file: "/code.js")
+            .data("key", "value")
+            .addCustomAttribute(name: "custom", value: "part")
+        let output = element.render(context: publishingContext)
+
+        XCTAssertEqual(output, "<script custom=\"part\" data-key=\"value\" src=\"/code.js\"></script>")
+    }
+}


### PR DESCRIPTION
The Script tag doesn't contain the attributes, but often there is a need for it.
E.g. `<script data-domain="site" src="/js/analytics.js"></script>`

This PR adds the CoreAttributes to the script tag and I added some tests for it.