### PR TITLE
New element: Abbreviation

### DIFF
--- a/Sources/Ignite/Elements/Abbreviation.swift
+++ b/Sources/Ignite/Elements/Abbreviation.swift
@@ -1,0 +1,35 @@
+//
+//  Abbreviation.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//  Created by Henrik Christensen on 2024-05-03.
+//
+
+import Foundation
+
+/// Renders an abbreviation.
+public struct Abbreviation: InlineElement {
+    /// The standard set of control attributes for HTML elements.
+    public var attributes = CoreAttributes()
+
+    /// The contents of this abbreviation.
+    public var contents: [InlineElement]
+    
+    /// Creates a new `Abbreviation` instance.
+    /// - Parameter abbreviation: The abbreviation.
+    /// - Parameter description: The description of the abbreviation.
+    public init(_ abbreviation: String, description: String) {
+        let customAttribute = AttributeValue(name: "title", value: description)
+        
+        self.attributes.customAttributes.append(customAttribute)
+        self.contents = [abbreviation]
+    }
+
+    /// Renders this element using publishing context passed in.
+    /// - Parameter context: The current publishing context.
+    /// - Returns: The HTML for this element.
+    public func render(context: PublishingContext) -> String {
+        "<abbr\(attributes.description)>\(contents.render(context: context))</abbr>"
+    }
+}

--- a/Tests/IgniteTests/Elements/Abbreviation.swift
+++ b/Tests/IgniteTests/Elements/Abbreviation.swift
@@ -1,0 +1,22 @@
+//
+//  Abbreviation.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//  Created by Henrik Christensen 2024-05-03.
+//
+
+import Foundation
+
+import XCTest
+@testable import Ignite
+
+/// Tests for the `Abbreviation` element.
+final class AbbreviationTests: ElementTest {
+    func test_singleElement() {
+        let element = Abbreviation("abbr", description: "abbreviation")
+        let output = element.render(context: publishingContext)
+
+        XCTAssertEqual(output, "<abbr title=\"abbreviation\">abbr</abbr>")
+    }
+}


### PR DESCRIPTION
This PR add an `Abbreviation` element. `Abbreviation` renders a `<abbr>` tag. This is something I find myself use from time to time and thought it'd be a nice addition to the collection of Ignite elements.

I added a single test for `Abbreviation`.