### PR TITLE
Changes to allow Ignite to generate a subsite

### DIFF
--- a/Sources/Ignite/Elements/Image.swift
+++ b/Sources/Ignite/Elements/Image.swift
@@ -94,7 +94,11 @@ public struct Image: BlockElement, InlineElement, LazyLoadable {
     ///   - context: The active publishing context.
     /// - Returns: The HTML for this element.
     private func render(image: String, description: String, into context: PublishingContext) -> String {
-        "<img src=\"\(image)\"\(attributes.description) alt=\"\(description)\"/>"
+        """
+            <img src=\"\(context.site.url.path)\(image)\" \
+            \(attributes.description)\
+            alt=\"\(description)\"/>
+            """
     }
 
     /// Renders this element using publishing context passed in.

--- a/Sources/Ignite/Elements/Link.swift
+++ b/Sources/Ignite/Elements/Link.swift
@@ -319,7 +319,9 @@ public struct Link: InlineElement, NavigationItem, DropdownElement {
     public func render(context: PublishingContext) -> String {
         let linkAttributes = attributes.appending(classes: linkClasses)
 
-        return "<a href=\"\(context.site.url.path)\(url)\"\(linkAttributes.description)>" +
-                                                            content.render(context: context) + "</a>"
+        // char[0] of the 'url' is '/' for an asset; not for a site URL
+        let basePath = url.starts(with: "/") ? context.site.url.path : ""
+        return "<link href=\"\(basePath)\(url)\"\(linkAttributes.description)>" + 
+                                               content.render(context: context) + "</a>"
     }
 }

--- a/Sources/Ignite/Elements/Link.swift
+++ b/Sources/Ignite/Elements/Link.swift
@@ -321,7 +321,7 @@ public struct Link: InlineElement, NavigationItem, DropdownElement {
 
         // char[0] of the 'url' is '/' for an asset; not for a site URL
         let basePath = url.starts(with: "/") ? context.site.url.path : ""
-        return "<link href=\"\(basePath)\(url)\"\(linkAttributes.description)>" + 
+        return "<a href=\"\(basePath)\(url)\"\(linkAttributes.description)>" + 
                                                content.render(context: context) + "</a>"
     }
 }

--- a/Sources/Ignite/Elements/Link.swift
+++ b/Sources/Ignite/Elements/Link.swift
@@ -319,6 +319,7 @@ public struct Link: InlineElement, NavigationItem, DropdownElement {
     public func render(context: PublishingContext) -> String {
         let linkAttributes = attributes.appending(classes: linkClasses)
 
-        return "<a href=\"\(url)\"\(linkAttributes.description)>" + content.render(context: context) + "</a>"
+        return "<a href=\"\(context.site.url.path)\(url)\"\(linkAttributes.description)>" +
+                                                            content.render(context: context) + "</a>"
     }
 }

--- a/Sources/Ignite/Elements/MetaLink.swift
+++ b/Sources/Ignite/Elements/MetaLink.swift
@@ -67,7 +67,12 @@ public struct MetaLink: HeadElement {
     /// Renders this element using publishing context passed in.
     /// - Parameter context: The current publishing context.
     /// - Returns: The HTML for this element.
+    ///
+    /// If the link `href` starts with a `\` it is an asset and requires any `subsite` prepended;
+    /// otherwise the `href` is a URL and  doesn't get `subsite` prepended
     public func render(context: PublishingContext) -> String {
-        "<link href=\"\(href)\" rel=\"\(rel)\">"
+        // char[0] of the link 'href' is '/' for an asset; not for a site URL
+        let basePath = href.starts(with: "/") ? context.site.url.path : ""
+        return "<link href=\"\(basePath)\(href)\" rel=\"\(rel)\">"
     }
 }

--- a/Sources/Ignite/Elements/Script.swift
+++ b/Sources/Ignite/Elements/Script.swift
@@ -44,7 +44,7 @@ public struct Script: BlockElement & HeadElement {
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
         if let file {
-            return "<script src=\"\(file)\"></script>"
+            return "<script src=\"\(context.site.url.path)\(file)\"></script>"
         } else if let code {
             return "<script>\(code)</script>"
         } else {

--- a/Sources/IgniteCLI/IgniteCLI.swift
+++ b/Sources/IgniteCLI/IgniteCLI.swift
@@ -25,7 +25,7 @@ struct IgniteCLI: ParsableCommand {
         commandName: "ignite",
         abstract: "A command-line tool for manipulating Ignite sites.",
         discussion: discussion,
-        version: "0.2.0",
+        version: "0.2.2",
         subcommands: [NewCommand.self, BuildCommand.self, RunCommand.self]
     )
 }

--- a/Sources/IgniteCLI/RunCommand.swift
+++ b/Sources/IgniteCLI/RunCommand.swift
@@ -55,6 +55,15 @@ struct RunCommand: ParsableCommand {
             return
         }
 
+        // Check for a subsite by not finding «href="/css/» in index.html.
+        if let indexData = FileManager.default.contents(atPath: "\(directory)/index.html") {
+            let indexString = String(decoding: indexData, as: UTF8.self)
+            guard indexString.contains("<link href=\"/css") else {
+                print("❌ This site specifies a custom subfolder, so it can't be previewed locally.")
+                return
+            }
+        }
+
         print("✅ Starting local web server on http://localhost:\(port)")
         print("Press ↵ Return to exit.")
 

--- a/Tests/IgniteTests/NonRoot Elements/SubsiteBody.swift
+++ b/Tests/IgniteTests/NonRoot Elements/SubsiteBody.swift
@@ -1,5 +1,5 @@
 //
-// SubsiteBody.swift                                (Created by Gavin Eadie on 2024-04-30)
+// SubsiteBody.swift                                
 // Ignite
 // https://www.github.com/twostraws/Ignite
 // See LICENSE for license information.

--- a/Tests/IgniteTests/NonRoot Elements/SubsiteImage.swift
+++ b/Tests/IgniteTests/NonRoot Elements/SubsiteImage.swift
@@ -1,5 +1,5 @@
 //
-// SubsiteImage.swift                               (Created by Gavin Eadie on 2024-04-30)
+// SubsiteImage.swift                               
 // Ignite
 // https://www.github.com/twostraws/Ignite
 // See LICENSE for license information.

--- a/Tests/IgniteTests/NonRoot Elements/SubsiteLink.swift
+++ b/Tests/IgniteTests/NonRoot Elements/SubsiteLink.swift
@@ -1,5 +1,5 @@
 //
-// SubsiteLink.swift                                (Created by Gavin Eadie on 2024-04-30)
+// SubsiteLink.swift                                
 // Ignite
 // https://www.github.com/twostraws/Ignite
 // See LICENSE for license information.

--- a/Tests/IgniteTests/NonRoot Elements/SubsiteScript.swift
+++ b/Tests/IgniteTests/NonRoot Elements/SubsiteScript.swift
@@ -1,5 +1,5 @@
 //
-// SubsiteScript.swift                              (Created by Gavin Eadie on 2024-04-30)
+// SubsiteScript.swift                              
 // Ignite
 // https://www.github.com/twostraws/Ignite
 // See LICENSE for license information.

--- a/Tests/IgniteTests/TestSubsite.swift
+++ b/Tests/IgniteTests/TestSubsite.swift
@@ -1,5 +1,5 @@
 //
-// TestSubsite.swift                                (Created by Gavin Eadie on 2024-04-30)
+// TestSubsite.swift                                
 // Ignite
 // https://www.github.com/twostraws/Ignite
 // See LICENSE for license information.


### PR DESCRIPTION
Ignite generates a website at the root of a web server: `http://site.com`

This change in the PR allows a site to be created to reside at: `http://site.com/subsite`

The change is driven by simply changing the URL in the `Site` struct

```
struct SampleSite: Site {
    var name = "Sample Ignite Site"
    var url = URL("http://site.com/subsite")    <--
     . . .
```

Unit tests have been added for those HTML elements that are impacted by this change.  Additionally, the **IgniteSamples** site has been generated as such a subsite, then tested for fidelity and a file-by-file comparison with the 'out of the box' version (including `Sitemap.XML` and the RSS feed URL).  That subsite version is at: `https://ramsaycons.com/ignitesamples`

One incomplete aspect of this change is that the `ignite run` command has not been changed to accommodate viewing the subsite [fixing this may be easy enough; I've not tried].  For viewing during development, the content of the Build directory needs to be placed in the correctly named directory of a 'real' web server (which could be one of several simple examples to run locally).

The Ignite CLI version, and the Git tag for this PR, are 0.2.2 ..