### PR TITLE
Allow enhancing standard header elements

### DIFF
--- a/Sources/Ignite/Elements/Head.swift
+++ b/Sources/Ignite/Elements/Head.swift
@@ -30,7 +30,7 @@ public struct Head: HTMLRootElement {
     ///   - page: The `Page` you want to create headers for.
     ///   - context: The active `PublishingContext`, which includes
     ///   information about the site being rendered and more.
-    public init(for page: Page, in context: PublishingContext) {
+    public init(for page: Page, in context: PublishingContext, @HeadElementBuilder additionalItems: () -> [HeadElement] = {[]}) {
         self.init {
             MetaTag.utf8
             MetaTag.flexibleViewport
@@ -65,6 +65,7 @@ public struct Head: HTMLRootElement {
         }
 
         items += MetaTag.socialSharingTags(for: page, context: context)
+        items += additionalItems()
     }
 
     /// Renders this element using publishing context passed in.

--- a/Sources/Ignite/Elements/Head.swift
+++ b/Sources/Ignite/Elements/Head.swift
@@ -30,6 +30,7 @@ public struct Head: HTMLRootElement {
     ///   - page: The `Page` you want to create headers for.
     ///   - context: The active `PublishingContext`, which includes
     ///   information about the site being rendered and more.
+    ///   - additionalItems: Additional items to enhance the set of standard headers.
     public init(for page: Page, in context: PublishingContext, @HeadElementBuilder additionalItems: () -> [HeadElement] = {[]}) {
         items = Head.standardHeaders(for: page, in: context)
 
@@ -44,6 +45,12 @@ public struct Head: HTMLRootElement {
         "<head>\(items.render(context: context))</head>"
     }
 
+    /// A static function, returning the standard set of headers used for a `Page` instance.
+    ///
+    /// This function can be used when defining a custom header based on the standard set of headers.
+    /// - Parameters:
+    ///   - page: The `Page` you want to create headers for.
+    ///   - context: The active `PublishingContext`, which includes
     @HeadElementBuilder
     public static func standardHeaders(for page: Page, in context: PublishingContext) -> [HeadElement] {
         MetaTag.utf8

--- a/Sources/Ignite/Elements/Head.swift
+++ b/Sources/Ignite/Elements/Head.swift
@@ -31,38 +31,7 @@ public struct Head: HTMLRootElement {
     ///   - context: The active `PublishingContext`, which includes
     ///   information about the site being rendered and more.
     public init(for page: Page, in context: PublishingContext, @HeadElementBuilder additionalItems: () -> [HeadElement] = {[]}) {
-        self.init {
-            MetaTag.utf8
-            MetaTag.flexibleViewport
-
-            if page.description.isEmpty == false {
-                MetaTag(name: "description", content: page.description)
-            }
-
-            if context.site.author.isEmpty == false {
-                MetaTag(name: "author", content: context.site.author)
-            }
-
-            MetaTag.generator
-
-            Title(page.title)
-
-            MetaLink.standardCSS
-
-            if context.site.syntaxHighlighters.isEmpty == false {
-                MetaLink.syntaxHighlightingCSS
-            }
-
-            if context.site.builtInIconsEnabled {
-                MetaLink.iconCSS
-            }
-
-            MetaLink(href: page.url, rel: "canonical")
-
-            if let favicon = context.site.favicon {
-                MetaLink(href: favicon, rel: .icon)
-            }
-        }
+        items = Head.standardHeaders(for: page, in: context)
 
         items += MetaTag.socialSharingTags(for: page, context: context)
         items += additionalItems()
@@ -73,5 +42,39 @@ public struct Head: HTMLRootElement {
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
         "<head>\(items.render(context: context))</head>"
+    }
+
+    @HeadElementBuilder
+    public static func standardHeaders(for page: Page, in context: PublishingContext) -> [HeadElement] {
+        MetaTag.utf8
+        MetaTag.flexibleViewport
+
+        if page.description.isEmpty == false {
+            MetaTag(name: "description", content: page.description)
+        }
+
+        if context.site.author.isEmpty == false {
+            MetaTag(name: "author", content: context.site.author)
+        }
+
+        MetaTag.generator
+
+        Title(page.title)
+
+        MetaLink.standardCSS
+
+        if context.site.syntaxHighlighters.isEmpty == false {
+            MetaLink.syntaxHighlightingCSS
+        }
+
+        if context.site.builtInIconsEnabled {
+            MetaLink.iconCSS
+        }
+
+        MetaLink(href: page.url, rel: "canonical")
+
+        if let favicon = context.site.favicon {
+            MetaLink(href: favicon, rel: .icon)
+        }
     }
 }


### PR DESCRIPTION
As described in #47 a common problem is that the standard header created by `Ignite` has to be enhanced with some additional elements.

With this PR I propose the enhancement of the current initializer `init(page:,in:)` to take an additional parameter which allows appending more elements to `Head`:

```swift
init(for page: Page, in context: PublishingContext, @HeadElementBuilder additionalItems: () -> [HeadElement] = {[]})
```

This allows enhancing the standard header with as shown below:

```swift
Head(for: page, in: context) {
    // Additional headers
    MetaLink(href: "/css/custom.css", rel: "stylesheet")
    Script(file: "/js/custom.js")
}
```