### PR TITLE
Feature: highlight active page in `NavigationBar`

### DIFF
--- a/Sources/Ignite/Elements/Dropdown.swift
+++ b/Sources/Ignite/Elements/Dropdown.swift
@@ -107,6 +107,7 @@ public struct Dropdown: BlockElement, NavigationItem {
                         if let link = item as? Link {
                             item.class("dropdown-item")
                                 .class(context.currentRenderingPath == link.url ? "active" : nil)
+                                .aria("current", context.currentRenderingPath == link.url ? "page" : nil)
                         } else {
                             item.class("dropdown-header")
                         }

--- a/Sources/Ignite/Elements/Dropdown.swift
+++ b/Sources/Ignite/Elements/Dropdown.swift
@@ -85,9 +85,12 @@ public struct Dropdown: BlockElement, NavigationItem {
     public func render(context: PublishingContext) -> String {
         Group(isTransparent: isNavigationItem) {
             if isNavigationItem {
+                let hasActiveItem = items.reduce(false) { partialResult, item in
+                    partialResult || context.currentRenderingPath == (item as? Link)?.url
+                }
                 Link(title, target: "#")
                     .addCustomAttribute(name: "role", value: "button")
-                    .class("dropdown-toggle", "nav-link")
+                    .class("dropdown-toggle", "nav-link", hasActiveItem ? "active" : nil)
                     .data("bs-toggle", "dropdown")
                     .aria("expanded", "false")
             } else {
@@ -101,8 +104,9 @@ public struct Dropdown: BlockElement, NavigationItem {
             List {
                 for item in items {
                     ListItem {
-                        if item is Link {
+                        if let link = item as? Link {
                             item.class("dropdown-item")
+                                .class(context.currentRenderingPath == link.url ? "active" : nil)
                         } else {
                             item.class("dropdown-header")
                         }

--- a/Sources/Ignite/Elements/Dropdown.swift
+++ b/Sources/Ignite/Elements/Dropdown.swift
@@ -85,9 +85,7 @@ public struct Dropdown: BlockElement, NavigationItem {
     public func render(context: PublishingContext) -> String {
         Group(isTransparent: isNavigationItem) {
             if isNavigationItem {
-                let hasActiveItem = items.reduce(false) { partialResult, item in
-                    partialResult || context.currentRenderingPath == (item as? Link)?.url
-                }
+                let hasActiveItem = items.contains { context.currentRenderingPath == ($0 as? Link)?.url  }
                 Link(title, target: "#")
                     .addCustomAttribute(name: "role", value: "button")
                     .class("dropdown-toggle", "nav-link", hasActiveItem ? "active" : nil)

--- a/Sources/Ignite/Elements/NavigationBar.swift
+++ b/Sources/Ignite/Elements/NavigationBar.swift
@@ -142,7 +142,7 @@ public struct NavigationBar: BlockElement {
                                 } else {
                                     ListItem {
                                         item
-                                            .class("nav-link")
+                                            .class("nav-link", context.currentRenderingPath == (item as? Link)?.url ? "active" : nil)
                                     }
                                     .class("nav-item")
                                 }

--- a/Sources/Ignite/Elements/NavigationBar.swift
+++ b/Sources/Ignite/Elements/NavigationBar.swift
@@ -143,6 +143,7 @@ public struct NavigationBar: BlockElement {
                                     ListItem {
                                         item
                                             .class("nav-link", context.currentRenderingPath == (item as? Link)?.url ? "active" : nil)
+                                            .aria("current", context.currentRenderingPath == (item as? Link)?.url ? "page" : nil)
                                     }
                                     .class("nav-item")
                                 }

--- a/Sources/Ignite/Elements/NavigationBar.swift
+++ b/Sources/Ignite/Elements/NavigationBar.swift
@@ -139,13 +139,16 @@ public struct NavigationBar: BlockElement {
                                     }
                                     .class("nav-item", "dropdown")
                                     .data("bs-theme", "light")
-                                } else {
+                                } else if let link = item as? Link {
                                     ListItem {
+                                        let isActive = context.currentRenderingPath == link.url
                                         item
-                                            .class("nav-link", context.currentRenderingPath == (item as? Link)?.url ? "active" : nil)
-                                            .aria("current", context.currentRenderingPath == (item as? Link)?.url ? "page" : nil)
+                                            .class("nav-link", isActive ? "active" : nil)
+                                            .aria("current", isActive ? "page" : nil)
                                     }
                                     .class("nav-item")
+                                } else {
+                                    item
                                 }
                             }
                         }

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -234,6 +234,8 @@ public class PublishingContext {
         }
     }
 
+    public var currentRenderingPath: String?
+
     /// Renders static pages and content pages, including the homepage.
     func generateContent() async throws {
         try await render(site.homePage, isHomePage: true)
@@ -245,6 +247,7 @@ public class PublishingContext {
         for content in allContent {
             try await render(content)
         }
+        currentRenderingPath = nil
     }
 
     /// Renders one page using the correct theme, which is taken either from the
@@ -301,6 +304,8 @@ public class PublishingContext {
     func render(_ staticPage: any StaticPage, isHomePage: Bool = false) async throws {
         let body = await Group(items: staticPage.body(context: self), context: self)
 
+        currentRenderingPath = isHomePage ? "/" : staticPage.path
+
         let path = isHomePage ? "" : staticPage.path
 
         let page = Page(
@@ -323,6 +328,8 @@ public class PublishingContext {
     func render(_ content: Content) async throws {
         let layout = try layout(for: content)
         let body = await Group(items: layout.body(content: content, context: self), context: self)
+
+        currentRenderingPath = content.path
 
         let image: URL?
 


### PR DESCRIPTION
This Pull Request implements highlighting the currently active page in the `NavigationBar` as illustrated with the image below. It supports `Link`s and `DropDown`s. The implementation relies on [Bootstraps "active" CSS class for "nav-link" elements](https://getbootstrap.com/docs/5.3/components/navbar/#nav).

Current issues: 

- ~~According to the documentation (see link above) one should add also "aria-current: true" attribute to the currently selected element. **To be implemented**~~
- "On-by-Default": the feature cannot be disabled/enabled. There are no configuration flags.
   **To be discussed**: Do we need configuration for this feature? If yes: wouldn't most users expect this feature to be active by default? This would cause regressions for existing users.
- The current implementation works, but is probably not nice: I had to add a new property `currentRenderingPath` to `PublishingContext` and set it accordingly in some `render` methods to allow checking for it in the `NavigationBar` implementation so we know which link should be marked as "active". I think this would be something to be added to an `@Environment`.

![Hightlight-active-page](https://github.com/twostraws/Ignite/assets/25307503/66093243-8b1e-40b7-aa2a-ce8631c8ffbc)
