### PR TITLE
Add NavigationBar column width modifier

### DIFF
--- a/Sources/Ignite/Elements/NavigationBar.swift
+++ b/Sources/Ignite/Elements/NavigationBar.swift
@@ -157,12 +157,12 @@ public struct NavigationBar: BlockElement {
                                 }
                             }
                         }
-                        .class("navbar-nav", "mb-2", "mb-md-0", columnWidth.className, itemAlignment.rawValue)
+                        .class("navbar-nav", "mb-2", "mb-md-0", "col", itemAlignment.rawValue)
                     }
                     .class("collapse", "navbar-collapse")
                     .id("navbarCollapse")
                 }
-                .class("container-fluid")
+                .class("container-fluid", columnWidth.className)
             }
             .attributes(attributes)
             .class("navbar", "navbar-expand-md")

--- a/Sources/Ignite/Elements/NavigationBar.swift
+++ b/Sources/Ignite/Elements/NavigationBar.swift
@@ -98,6 +98,15 @@ public struct NavigationBar: BlockElement {
         copy.itemAlignment = alignment
         return copy
     }
+    
+    /// Adjust the width of the navigation bar
+    /// - Parameter columnWidth: How many columns this should occupy when placed in a section.
+    /// - Returns: A new `NavigationBar` instance with the updated column width
+    public func navigationBarColumnWidth(_ columnWidth: ColumnWidth) -> Self {
+        var copy = self
+        copy.columnWidth = columnWidth
+        return copy
+    }
 
     func theme(for style: NavigationBarStyle) -> String? {
         switch style {
@@ -148,7 +157,7 @@ public struct NavigationBar: BlockElement {
                                 }
                             }
                         }
-                        .class("navbar-nav", "mb-2", "mb-md-0", "col", itemAlignment.rawValue)
+                        .class("navbar-nav", "mb-2", "mb-md-0", columnWidth.className, itemAlignment.rawValue)
                     }
                     .class("collapse", "navbar-collapse")
                     .id("navbarCollapse")

--- a/Tests/IgniteTests/Elements/NavigationBar.swift
+++ b/Tests/IgniteTests/Elements/NavigationBar.swift
@@ -15,13 +15,13 @@ final class NavigationBarTests: ElementTest {
         let element = NavigationBar()
         let output = element.render(context: publishingContext)
         
-        XCTAssertTrue(output.contains("navbar-nav mb-2 mb-md-0 col"))
+        XCTAssertTrue(output.contains("container-fluid col"))
     }
     
     func test_columnWidthValueSet() {
         let element = NavigationBar().navigationBarColumnWidth(.count(10))
         let output = element.render(context: publishingContext)
         
-        XCTAssertTrue(output.contains("navbar-nav mb-2 mb-md-0 col-md-10"))
+        XCTAssertTrue(output.contains("container-fluid col-md-10"))
     }
 }

--- a/Tests/IgniteTests/Elements/NavigationBar.swift
+++ b/Tests/IgniteTests/Elements/NavigationBar.swift
@@ -1,0 +1,27 @@
+//
+// NavigationBar.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+import XCTest
+@testable import Ignite
+
+/// Tests for the `NavigationBar` element.
+final class NavigationBarTests: ElementTest {
+    
+    func test_defaultColumnWidth() {
+        let element = NavigationBar()
+        let output = element.render(context: publishingContext)
+        
+        XCTAssertTrue(output.contains("navbar-nav mb-2 mb-md-0 col"))
+    }
+    
+    func test_columnWidthValueSet() {
+        let element = NavigationBar().navigationBarColumnWidth(.count(10))
+        let output = element.render(context: publishingContext)
+        
+        XCTAssertTrue(output.contains("navbar-nav mb-2 mb-md-0 col-md-10"))
+    }
+}


### PR DESCRIPTION
This Pull Request adds a modifier to set the `columnWidth` of the NavigationBar. The property was already present but not used. It only affects the horizontal  placement of the navigation bar items. 

<img width="1511" alt="Screenshot 2024-05-14 at 14 00 08" src="https://github.com/twostraws/Ignite/assets/14346557/60f16b72-c4ab-4f1a-8e98-a9bdfd98e990">
