### PR TITLE
Reading a Markdown file that causes an 'encoding' error throws a confusing error ..

### DIFF
--- a/Sources/Ignite/Publishing/PublishingError.swift
+++ b/Sources/Ignite/Publishing/PublishingError.swift
@@ -17,6 +17,9 @@ public enum PublishingError: LocalizedError {
     /// Invalid Markdown was found at the specific URL.
     case badMarkdown(URL)
 
+    /// A file cannot be opened (bad encoding, etc).
+    case unopenableFile(String)
+
     /// Publishing attempted to remove the build directory, but failed.
     case failedToRemoveBuildDirectory(URL)
 
@@ -65,6 +68,8 @@ public enum PublishingError: LocalizedError {
             "Unable to locate Package.swift."
         case .badMarkdown(let url):
             "Markdown could not be parsed: \(url.absoluteString)."
+        case .unopenableFile(let reason):
+            "Failed to open file: \(reason)."
         case .failedToRemoveBuildDirectory(let url):
             "Failed to clear the build folder: \(url.absoluteString)."
         case .failedToCreateBuildDirectory(let url):

--- a/Sources/Ignite/Rendering/Markdown/MarkdownToHTML.swift
+++ b/Sources/Ignite/Rendering/Markdown/MarkdownToHTML.swift
@@ -45,9 +45,14 @@ public struct MarkdownToHTML: MarkdownRenderer, MarkupVisitor {
     ///   - removeTitleFromBody: True if the first title should be removed
     ///   from the final `body` property.
     public init(url: URL, removeTitleFromBody: Bool) throws {
+        self.removeTitleFromBody = removeTitleFromBody
+        var markdown: String
         do {
-            self.removeTitleFromBody = removeTitleFromBody
-            let markdown = try String(contentsOf: url)
+            markdown = try String(contentsOf: url)
+        } catch {
+            throw PublishingError.unopenableFile(error.localizedDescription)
+        }
+        do {
             let processed = processMetadata(for: markdown)
             let document = Document(parsing: processed)
             body = visit(document)
@@ -56,8 +61,6 @@ public struct MarkdownToHTML: MarkdownRenderer, MarkupVisitor {
                 // Assign a title that's better than the default empty string.
                 title = url.deletingPathExtension().lastPathComponent
             }
-        } catch let error as NSError {
-            throw error
         } catch {
             throw PublishingError.badMarkdown(url)
         }

--- a/Sources/Ignite/Rendering/Markdown/MarkdownToHTML.swift
+++ b/Sources/Ignite/Rendering/Markdown/MarkdownToHTML.swift
@@ -56,6 +56,8 @@ public struct MarkdownToHTML: MarkdownRenderer, MarkupVisitor {
                 // Assign a title that's better than the default empty string.
                 title = url.deletingPathExtension().lastPathComponent
             }
+        } catch let error as NSError {
+            throw error
         } catch {
             throw PublishingError.badMarkdown(url)
         }


### PR DESCRIPTION
Ingite reports the reading of a Markdown file with unknown encoding as a parsing error.  This PR catches the file error early and throws that before the parse is tried.