### PR TITLE
adds `SocialIcon` to Framework, SocialFooter to Components

### DIFF
--- a/Sources/Ignite/Components/SocialFooter.swift
+++ b/Sources/Ignite/Components/SocialFooter.swift
@@ -1,0 +1,41 @@
+//
+// SocialFooter.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+// Created by joshua kaunert on 6/14/24.
+//
+
+import Foundation
+
+/// Displays "Social Footer", with each icon opening an external social site in a new browser tab.
+public struct SocialFooter: Component {
+    /// the array of `Links` to use in the social footer, populated using an array of `SocialIcons` passed into initializer
+    var links: [Link] = []
+    
+    /// Initializer constructs `Link`s from user provided array of `SocialIcon`s and appends each to `links` array
+    public init(_ icons: [SocialIcon]) {
+        for icon in icons {
+            links.append(
+                Link(icon.image, target: icon.targetURL)
+                    .target(.blank)
+                    .relationship(.noOpener, .noReferrer)
+                    .margin(.trailing, 20)
+                    .role(.secondary)
+            )
+        }
+    }
+
+    public func body(context: PublishingContext) -> [any PageElement] {
+        
+        Text {
+            /// Iterates over `links` and adds each link to the `Text` element
+            for link in links {
+                link
+            }
+        }
+        .font(.title2)
+        .horizontalAlignment(.center)
+        .margin(.top, .extraLarge)
+    }
+}

--- a/Sources/Ignite/Framework/SocialIcon.swift
+++ b/Sources/Ignite/Framework/SocialIcon.swift
@@ -1,0 +1,40 @@
+//
+// SocialIcon.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+// Created by joshua kaunert on 6/14/24.
+//
+
+import Foundation
+
+/// represents a single social icon
+public struct SocialIcon {
+    /// name of built-in icon (Built-in icons must be enabled)
+    /// see https://icons.getbootstrap.com/?q=social for complete list
+    let iconName: String
+    /// the url target
+    let targetURL: String
+    /// location of image file if not using built-in
+    let customImageURL: String?
+    
+    /// computed property, returns either built-in image, or custom image if passed a `customImageURL`
+    var image: Image {
+        if let imageURL = customImageURL {
+            Image(decorative: imageURL)
+                .frame(width: 32)
+                .resizable()
+                .opacity(0.74)
+                .foregroundStyle(.secondary)
+        } else {
+            Image(systemName: iconName)
+                .opacity(0.74)
+        }
+    }
+    
+    public init(name: String, targetURL: String, customImageURL: String? = nil) {
+        self.iconName = name
+        self.targetURL = targetURL
+        self.customImageURL = customImageURL
+    }
+}


### PR DESCRIPTION
Adds a `SocialFooter` component with a `SocialIcon` struct to allow for easy addition of a social footer.

usage:
```
Group {
    SocialFooter([
      SocialIcon(
          name: "medium",
          targetURL: "https://medium.com/alwaysmakingstuff"
          ),
      SocialIcon(
          name: "github",
          targetURL: "https://github.com/always-making-stuff"
          ),
      SocialIcon(
          name: "twitch",
          targetURL: "https://twitch.tv/alwaysmakingstuff"
          ),
      SocialIcon(
          name: "YouTube",
          targetURL: "https://youtube.com/alwaysmakingstuff"
          ),
      SocialIcon(
          name: "bluesky",
          targetURL: "https://bsky.app/profile/joshuaauhsoj.bsky.social",
          customImageURL: "/images/social/bluesky.svg"
          ),
      ])
    IgniteFooter()
}
```

<img width="591" alt="SocialFooterExample" src="https://github.com/twostraws/Ignite/assets/44586402/a694f02b-9ff4-411b-ac03-d2afd9bff3d9">