### PR TITLE
Feature / Close button

### DIFF
--- a/Sources/Ignite/Elements/Button.swift
+++ b/Sources/Ignite/Elements/Button.swift
@@ -123,7 +123,6 @@ public struct Button: InlineElement {
         switch role {
         case .default:
             break
-
         default:
             outputClasses.append("btn-\(role.rawValue)")
         }
@@ -131,11 +130,22 @@ public struct Button: InlineElement {
         return outputClasses
     }
 
+    public static func aria(forRole role: Role) -> AttributeValue? {
+        switch role {
+        case .close:
+            AttributeValue(name: "label", value: "Close")
+        default:
+            nil
+        }
+    }
+
     /// Renders this element using publishing context passed in.
     /// - Parameter context: The current publishing context.
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
-        let buttonAttributes = attributes.appending(classes: Button.classes(forRole: role, size: size))
+        let buttonAttributes = attributes
+            .appending(classes: Button.classes(forRole: role, size: size))
+            .appending(aria: Button.aria(forRole: role))
         let output = label.map { $0.render(context: context) }.joined()
         return "<button type=\"\(type.htmlName)\"\(buttonAttributes.description)>\(output)</button>"
     }

--- a/Sources/Ignite/Styles/CoreAttributes.swift
+++ b/Sources/Ignite/Styles/CoreAttributes.swift
@@ -139,6 +139,19 @@ public struct CoreAttributes {
         return copy
     }
 
+    /// Returns a new set of attributs with an extra aria appended
+    /// - Parameter aria: The aria to append
+    /// - Returns: A copy of the previous `CoreAttributes` object with
+    /// the extra aria applied.
+    func appending(aria: AttributeValue?) -> CoreAttributes {
+        guard let aria else {
+            return self
+        }
+        var copy = self
+        copy.aria.append(aria)
+        return copy
+    }
+
     /// Returns a new set of attributes with extra inline CSS styles appended.
     /// - Parameter classes: The inline CSS styles to append.
     /// - Returns: A copy of the previous `CoreAttributes` object with

--- a/Sources/Ignite/Styles/Role.swift
+++ b/Sources/Ignite/Styles/Role.swift
@@ -20,6 +20,9 @@ public enum Role: String, CaseIterable {
     /// A secondary element.
     case secondary
 
+    /// Represents a close element
+    case close
+
     /// This element represents the successful result of something, or otherwise
     /// positive information.
     case success


### PR DESCRIPTION
This PR adds the option to create close button consisting of a cross by setting the role to `close`. It is related to Issue #74 

You can create a button like this:
```swift
Button({}) {
    SomeAction()
}.role(.close)
```
or 
```swift
Button {
    SomeAction()
}
.role(.close)
.onTap
```