### PR TITLE
Feature / Modal View

### DIFF
--- a/Sources/Ignite/Actions/DismissModal.swift
+++ b/Sources/Ignite/Actions/DismissModal.swift
@@ -1,0 +1,31 @@
+//
+// DismissModal.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+
+/// Dismiss a modal dialog with the content of the page element identified by ID
+public struct DismissModal: Action {
+    /// The unique identifier of the element of the modal we're trying to dismiss.
+    var id: String
+
+    /// Creates a new DismissModal action from a specific page element ID.
+    /// - Parameter id: The unique identifier of the element of the modal we're trying to dismiss.
+    public init(id: String) {
+        self.id = id
+    }
+
+    /// Renders this action using publishing context passed in.
+    /// - Returns: The JavaScript for this action.
+    public func compile() -> String {
+        """
+        const modal = document.getElementById('\(id)');
+        const modalInstance = bootstrap.Modal.getInstance(modal);
+        if (modalInstance) { modalInstance.hide(); }
+        """
+    }
+}
+

--- a/Sources/Ignite/Actions/ShowModal.swift
+++ b/Sources/Ignite/Actions/ShowModal.swift
@@ -1,0 +1,68 @@
+//
+// HideElement.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+
+/// Shows a modal dialog with the content of the page element identified by ID
+public struct ShowModal: Action {
+
+    /// The options used to configure the modal presentation
+    public enum Option {
+        /// Shows the modal with a backdrop optionally dismissible by clicking on the backdrop.
+        /// - Parameter dismissible: Whether the modal can be dismissed by clicking on the backdrop. Default is `true`.
+        case backdrop(dismissible: Bool)
+
+        /// Shows the modal without backdrop. It is not dismissed when clicking outside the modal.
+        case noBackdrop
+
+        /// Focuses on the modal when opened.
+        /// - Parameter bool: Whether the modal should be focused when opened. Default is `true`.
+        case focus(Bool)
+
+        /// Option to close the modal when escape key is pressed.
+        /// - Parameter bool: Whether the modal should close when escape key is pressed. Default is `true`.
+        case keyboard(Bool)
+
+        var htmlOption: String {
+            switch self {
+            case .backdrop(let dismissable):
+                "backdrop: \(dismissable ? "true" : "'static'")"
+            case .noBackdrop:
+                "backdrop: false"
+            case .focus(let bool):
+                "focus: \(bool.description)"
+            case .keyboard(let bool):
+                "keyboard: \(bool.description)"
+            }
+        }
+    }
+
+    /// The unique identifier of the element to display in the modal dialog.
+    let id: String
+
+    /// The options used to configure the modal
+    let options: [Option]
+
+    /// Creates a new ShowModal action from a specific page element ID.
+    /// - Parameter id: The unique identifier of the element we're trying to show as a modal.
+    public init(id: String, options: [Option] = []) {
+        self.id = id
+        self.options = options
+    }
+
+    /// Renders this action using publishing context passed in.
+    /// - Returns: The JavaScript for this action.
+    public func compile() -> String {
+        """
+        const options = {
+            \(options.map { $0.htmlOption }.joined(separator: ",\n\t"))
+        };
+        const modal = new bootstrap.Modal(document.getElementById('\(id)'), options);
+        modal.show();
+        """
+    }
+}

--- a/Sources/Ignite/Elements/Modal.swift
+++ b/Sources/Ignite/Elements/Modal.swift
@@ -1,0 +1,164 @@
+//
+// Modal.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+
+/// A modal dialog presented on top of the screen
+public struct Modal: PageElement {
+    
+    /// The size of the modal. Except from the full screen modal the height is defined by the height wheras the width
+    public enum Size {
+        /// A modal dialog with a small max-width of 300px
+        
+        case small
+        /// A modal dialog with a medium max-width of 500px
+        
+        case medium
+        /// A modal dialog with a large max-width of 800px
+        
+        case large
+        /// A modal dialog with an extra large wmax-idth of 1140px
+        
+        case xLarge
+        
+        /// A fullscreen modal dialog covering the entre view port
+        case fullscreen
+
+        /// The HTML name for the modal size.
+        var htmlClass: String? {
+            switch self {
+            case .small:
+                "modal-sm"
+            case .medium:
+                nil
+            case .large:
+                "modal-lg"
+            case .xLarge:
+                "modal-xl"
+            case .fullscreen:
+                "modal-fullscreen"
+            }
+        }
+    }
+
+    public enum Position {
+        case top
+        case center
+
+        var htmlName: String? {
+            switch self {
+            case .top:
+                nil
+            case .center:
+                "modal-dialog-centered"
+            }
+        }
+    }
+
+    /// The standard set of control attributes for HTML elements.
+    public var attributes = CoreAttributes()
+
+    let id: String
+    var items: [any PageElement] = []
+    var header:[any PageElement] = []
+    var footer: [any PageElement] = []
+
+    var animated = true
+    var scrollable = false
+    var size: Size = .medium
+    var position: Position = .center
+
+    public init(
+        id modalId: String, 
+        @PageElementBuilder body: () -> [PageElement],
+        @PageElementBuilder header: () -> [PageElement] = { [] },
+        @PageElementBuilder footer: () -> [PageElement] = { [] }
+    ) {
+        self.id = modalId
+        self.items = body()
+        self.header = header()
+        self.footer = footer()
+    }
+    
+    /// Adjusts the size of the modal.
+    /// - Parameter size: The size of the presented modal.
+    /// - Returns: A new `Modal` instance with the updated size setting.
+    public func size(_ size: Size) -> Self {
+        var copy = self
+        copy.size = size
+        return copy
+    }
+
+    /// Adjusts the animation setting for a modal presentation.
+    /// - Parameter animated: A boolean value that determines whether the modal presentation should be animated.
+    /// - Returns: A new `Modal` instance with the updated animation setting.
+    public func animated(_ animated: Bool) -> Self {
+        var copy = self
+        copy.animated = animated
+        return copy
+    }
+    
+    /// Adjusts the position of the modal view
+    /// - Parameter position: The desired vertical position of the modal on the screen.
+    /// - Returns: A new `Modal` instance with the updated vertical position.
+    public func modalPosition(_ position: Position) -> Self {
+        var copy = self
+        copy.position = position
+        return copy
+    }
+    
+    /// Determines whether the modal view's content is scrollable.
+    /// - Parameter scrollable: A boolean value that determines whether the modal view's content should be scrollable.
+    /// - Returns: A new `Modal` instance with the updated scrollable content setting.
+    public func scrollableContent(_ scrollable: Bool) -> Self {
+        var copy = self
+        copy.scrollable = scrollable
+        return copy
+    }
+
+    /// Renders this element using publishing context passed in.
+    /// - Parameter context: The current publishing context.
+    /// - Returns: The HTML for this element.
+    public func render(context: PublishingContext) -> String {
+        Group {
+            Group {
+                Group {
+                    Group {
+                        for item in header {
+                            item
+                        }
+                    }
+                    .class("modal-header")
+
+                    Group {
+                        for item in items {
+                            item
+                        }
+                    }
+                    .class("modal-body")
+                    
+                    Group {
+                        for item in footer {
+                            item
+                        }
+                    }
+                    .class("modal-footer")
+                }
+                .class("modal-content")
+            }
+            .class("modal-dialog")
+            .class(size.htmlClass)
+            .class(position.htmlName)
+            .class(scrollable ? "modal-dialog-scrollable" : nil)
+        }
+        .class(animated ? "modal fade" : "modal")
+        .id(id)
+        .aria("labelledby", "modalLabel")
+        .aria("hidden", "true")
+        .render(context: context)
+    }
+}

--- a/Sources/Ignite/Elements/Modal.swift
+++ b/Sources/Ignite/Elements/Modal.swift
@@ -127,12 +127,15 @@ public struct Modal: PageElement {
         Group {
             Group {
                 Group {
-                    Group {
-                        for item in header {
-                            item
+
+                    if header.isEmpty == false {
+                        Group {
+                            for item in header {
+                                item
+                            }
                         }
+                        .class("modal-header")
                     }
-                    .class("modal-header")
 
                     Group {
                         for item in items {
@@ -141,12 +144,14 @@ public struct Modal: PageElement {
                     }
                     .class("modal-body")
                     
-                    Group {
-                        for item in footer {
-                            item
+                    if footer.isEmpty == false {
+                        Group {
+                            for item in footer {
+                                item
+                            }
                         }
+                        .class("modal-footer")
                     }
-                    .class("modal-footer")
                 }
                 .class("modal-content")
             }


### PR DESCRIPTION
This PR adds the option to create modal views. It can be configured to look like a modal dialog or by omitting the header and footer show any content provided in the body. 

### Show / Dismiss

It can be shown via the `ShowModal` action and hidden either by tapping on the backdrop or by using the `DismissModal` action. 

### Options

There are a few modifies available to configure e.g. 
* the size
* the backdrop
* dismissal behavior
* vertical position 
* if the content should be scrollable

### Example
```swift
Button("Tap me") {
    ShowModal(id: "myModalId")
}

Modal(id: "myModalId") {
    "Hello, World!"
}
.size(.large)
```