### PR TITLE
Added .newWindow to open new window however keeping .blank as well

### DIFF
--- a/Sources/Ignite/Elements/Link.swift
+++ b/Sources/Ignite/Elements/Link.swift
@@ -123,6 +123,9 @@ public struct Link: InlineElement, NavigationItem, DropdownElement {
         /// The page should be opened in a new window.
         case blank
 
+        /// The page should be opened in a new window. (same as `.blank`)`
+        case newWindow
+
         /// The page should be opened in the parent window.
         case parent
 
@@ -139,6 +142,8 @@ public struct Link: InlineElement, NavigationItem, DropdownElement {
             case .default:
                 nil
             case .blank:
+                "_blank"
+            case .newWindow:
                 "_blank"
             case .parent:
                 "_parent"


### PR DESCRIPTION
I keeped the .blank for as you said it a prior art for html to use blank and it might break some code. I do feel that it would be useful as I did not realise and took me awhile to find this, and other web site builder seam to use open in new window for their links