### PR TITLE
Bugfix / Modals not dismissable via Esc key

### DIFF
--- a/Sources/Ignite/Elements/Modal.swift
+++ b/Sources/Ignite/Elements/Modal.swift
@@ -161,6 +161,7 @@ public struct Modal: PageElement {
             .class(scrollable ? "modal-dialog-scrollable" : nil)
         }
         .class(animated ? "modal fade" : "modal")
+        .tabFocus(.focusable)
         .id(id)
         .aria("labelledby", "modalLabel")
         .aria("hidden", "true")

--- a/Sources/Ignite/Framework/ElementTypes/PageElement.swift
+++ b/Sources/Ignite/Framework/ElementTypes/PageElement.swift
@@ -123,6 +123,10 @@ extension PageElement {
         return copy
     }
 
+    /// Sets the tab focus (a.k.a tabindex) of this element.
+    /// **Important:** Use this with caution as it is easy to make mistakes and cause problems with screen readers.
+    /// - Parameter tabFocus: The desired `TabFocus` enum value
+    /// - Returns: A copy of the current element with the tap focus applied.
     public func tabFocus(_ tabFocus: TabFocus) -> Self {
         addCustomAttribute(name: tabFocus.htmlName, value: tabFocus.value)
     }

--- a/Sources/Ignite/Framework/ElementTypes/PageElement.swift
+++ b/Sources/Ignite/Framework/ElementTypes/PageElement.swift
@@ -122,4 +122,8 @@ extension PageElement {
         copy.attributes = attributes
         return copy
     }
+
+    public func tabFocus(_ tabFocus: TabFocus) -> Self {
+        addCustomAttribute(name: tabFocus.htmlName, value: tabFocus.value)
+    }
 }

--- a/Sources/Ignite/Rendering/TabFocus.swift
+++ b/Sources/Ignite/Rendering/TabFocus.swift
@@ -1,0 +1,38 @@
+//
+// TabFocus.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+
+/// An enum representing the `tabindex` attribute for controlling the tab order and focus behavior of HTML elements.
+public enum TabFocus {
+    /// The element is focusable but not part of the tab order (equivalent to `tabindex="-1"`).
+    case focusable
+
+    /// The element is focusable and part of the natural tab order (equivalent to `tabindex="0"`).
+    case auto
+
+    /// The element is focusable and has a custom tab order specified by the associated integer value (equivalent to `tabindex` with a positive integer).
+    /// - Parameter index: A positive integer specifying the custom tab order.
+    case custom(Int)
+
+    /// The `tabindex` value corresponding to the enum case.
+    var value: String {
+        switch self {
+        case .focusable:
+            return "-1"
+        case .auto:
+            return "0"
+        case .custom(let index):
+            return "\(index)"
+        }
+    }
+
+    /// The html tabindex key-value pair representing the `TabFocus` case
+    var htmlName: String {
+        "tabindex"
+    }
+}


### PR DESCRIPTION
This PR introduces the html attribute `tabindex` which is necessary to be set on modals to be dismissible via the `Esc` key. 

While I could have just used a custom attribute, I thought modeling it in a "swifty" manner could be of value for other use cases. 

I choose the name `TabFocus` to more clearly hint on its usage but going for `TabIndex` might be more inline with web development. Curious about other opinions here. 