### PR TITLE
Split Makefile into a build and install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,7 @@ install:
 	@echo "Installing the Ignite command-line tool...\\n"
 	@[ $(shell id -u) -eq 0 ] && sudo mkdir -p /usr/local/bin || { echo "You do not have root permissions. Either manually create the /usr/local/bin directory or run as \'sudo\'"; exit 126; }
 	@(install .build/release/IgniteCLI /usr/local/bin/ignite 2> /dev/null && (echo \\n✅ Success! Run \`ignite\` to get started.)) || (echo \\n❌ Installation failed. You might need to run \`sudo make\` instead.\\n)
+
+clean:
+	@echo "Cleaning the Ignite build folder...\\n"
+	@rm -rf .build/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
-install:
+build:
 	@echo "Building the Ignite command-line tool...\\n"
 	@swift build -c release --product IgniteCLI
+
+install:
+	@echo "Installing the Ignite command-line tool...\\n"
 	@[ $(shell id -u) -eq 0 ] && sudo mkdir -p /usr/local/bin || { echo "You do not have root permissions. Either manually create the /usr/local/bin directory or run as \'sudo\'"; exit 126; }
 	@(install .build/release/IgniteCLI /usr/local/bin/ignite 2> /dev/null && (echo \\n✅ Success! Run \`ignite\` to get started.)) || (echo \\n❌ Installation failed. You might need to run \`sudo make\` instead.\\n)

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ The easiest way to get started is to use the Ignite command-line tool included w
 
 1. Run `git clone https://github.com/twostraws/Ignite` to clone this repository to your computer.
 2. Change into the new directory, e.g. `cd Ignite`.
-3. Now run `make install` to build and install the Ignite command-line tool.
-4. If that command fails because of permissions issues, you should run `sudo make install` instead.
+3. Now run `make` to build the Ignite command-line tool.
+4. Then run `make install` to install the Ignite command-line tool.
+5. If that command fails because of permissions issues, you should run `sudo make install` instead.
 
 Once that command-line tool is installed, you can run the following command to create a new site called ExampleSite:
 


### PR DESCRIPTION
So building can be done as non-privileged user and only requiring install to be done as root.