### PR TITLE
Feature / Hover Link Style

### DIFF
--- a/Sources/Ignite/Elements/Link.swift
+++ b/Sources/Ignite/Elements/Link.swift
@@ -152,7 +152,7 @@ public struct Link: InlineElement, NavigationItem, DropdownElement {
 
     /// Allows you to style links as buttons if needed.
     public enum LinkStyle: String, CaseIterable {
-        case `default`, button
+        case `default`, hover, button
     }
 
     /// The standard set of control attributes for HTML elements.
@@ -178,12 +178,18 @@ public struct Link: InlineElement, NavigationItem, DropdownElement {
     var linkClasses: [String] {
         var outputClasses = [String]()
 
-        if style == .default {
+        if style == .button {
+            outputClasses.append(contentsOf: Button.classes(forRole: role, size: size))
+        } else {
             if role != .default {
                 outputClasses.append("link-\(role.rawValue)")
             }
-        } else {
-            outputClasses.append(contentsOf: Button.classes(forRole: role, size: size))
+            if style == .hover {
+                outputClasses.append(contentsOf: [
+                    "link-underline-opacity-0",
+                    "link-underline-opacity-100-hover"
+                ])
+            }
         }
 
         return outputClasses


### PR DESCRIPTION
This PR adds a new link style called hover. With this style a link is only underlined when hovering over the text.