### PR TITLE
Feature / Box Shadow on Hover

### DIFF
--- a/Sources/Ignite/Actions/HideBoxShadow.swift
+++ b/Sources/Ignite/Actions/HideBoxShadow.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Mark Stamer on 03.07.24.
+//
+
+import Foundation

--- a/Sources/Ignite/Actions/HideBoxShadow.swift
+++ b/Sources/Ignite/Actions/HideBoxShadow.swift
@@ -1,8 +1,21 @@
 //
-//  File.swift
-//  
-//
-//  Created by Mark Stamer on 03.07.24.
+// ShowBoxShadow.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
 //
 
 import Foundation
+
+/// Hides a previously applied box shadow of the element it is applied to, e.g. onHover(false).
+public struct HideBoxShadow: Action {
+
+    /// Creates a new HideBoxShadow action.
+    public init() { }
+
+    /// Renders this action using publishing context passed in.
+    /// - Returns: The JavaScript for this action.
+    public func compile() -> String {
+        "this.style.boxShadow=''"
+    }
+}

--- a/Sources/Ignite/Actions/ShowBoxShadow.swift
+++ b/Sources/Ignite/Actions/ShowBoxShadow.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Mark Stamer on 03.07.24.
+//
+
+import Foundation

--- a/Sources/Ignite/Actions/ShowBoxShadow.swift
+++ b/Sources/Ignite/Actions/ShowBoxShadow.swift
@@ -1,8 +1,37 @@
 //
-//  File.swift
-//  
-//
-//  Created by Mark Stamer on 03.07.24.
+// ShowBoxShadow.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
 //
 
 import Foundation
+
+/// Shows a box shadow around the element it is applied e.g. onHover(true)
+public struct ShowBoxShadow: Action {
+    var color: Color = .black.opacity(0.1)
+    var radius: Int = 8
+    var x: Int = 0
+    var y: Int = 0
+    
+    /// Creates a ShowBoxShadow action with the provided shadow parameters
+    /// - Parameters:
+    ///   - color: The shadow's color.
+    ///   - radius: The shadow's radius
+    ///   - x: The X offset for the shadow, specified in pixels. Defaults to 0.
+    ///   - y: The Y offset for the shadow, specified in pixels. Defaults to 0.
+    public init(color: Color = .black.opacity(0.1), radius: Int = 8, x: Int = 0, y: Int = 0) {
+        self.color = color
+        self.radius = radius
+        self.x = x
+        self.y = y
+    }
+
+    var shadow: Shadow {
+        Shadow(color: color, radius: radius, x: x, y: y)
+    }
+
+    public func compile() -> String {
+        "this.style.boxShadow='\(shadow.description)'"
+    }
+}

--- a/Sources/Ignite/Modifiers/HoverEffect.swift
+++ b/Sources/Ignite/Modifiers/HoverEffect.swift
@@ -1,0 +1,85 @@
+//
+// HoverEffect.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+
+public extension PageElement {
+    /// Applies a hover effect to the page element
+    /// - Parameter effect: A closure that returns the effect to be applied. The argument acts as a placeholder representing this page element.
+    /// - Returns: The page element with the provided hover effect applied.
+    @discardableResult
+    func hoverEffect(_ effect: @escaping (EmptyHoverEffect) -> some HoverEffect) -> Self {
+        onHover { isHovering in
+            if isHovering {
+                ApplyHoverEffects(styles: effect(EmptyHoverEffect()).styles)
+            } else {
+                RemoveHoverEffects()
+            }
+        }
+    }
+}
+
+/// A protocol representing the hover effect css styles to be applied
+public protocol HoverEffect {
+    var styles: [AttributeValue] { get set }
+}
+
+/// An empty hover effect type to which styles can be added
+public struct EmptyHoverEffect: HoverEffect {
+    public var styles: [AttributeValue] = []
+}
+
+extension HoverEffect {
+    /// Adds a shadow hover effect
+    /// - Parameters:
+    ///   - color: The shadow's color. Defaults to black at 33% opacity.
+    ///   - radius: The shadow's radius
+    ///   - x: The X offset for the shadow, specified in pixels. Defaults to 0.
+    ///   - y: The Y offset for the shadow, specified in pixels. Defaults to 0.
+    /// - Returns: A copy of the hover effect with the shadow hover effect applied.
+    public func shadow(color: Color = .black.opacity(0.1), radius: Int = 8, x: Int = 0, y: Int = 0) -> some HoverEffect {
+        addingStyle(.init(
+            name: "boxShadow",
+            value: "\(Shadow(color: color, radius: radius, x: x, y: y))")
+        )
+    }
+    
+    /// Adds background color hover effect
+    /// - Parameter color: The color to be used for the background
+    /// - Returns: A copy of the hover effect with the color hover effect applied.
+    public func background(_ color: Color) -> some HoverEffect {
+        addingStyle(.init(
+            name: "backgroundColor",
+            value: "\(color)")
+        )
+    }
+
+    func addingStyle(_ style: AttributeValue) -> some HoverEffect {
+        var copy = self
+        copy.styles.append(style)
+        return copy
+    }
+}
+
+private struct ApplyHoverEffects: Action {
+    let styles: [AttributeValue]
+
+    func compile() -> String {
+        """
+        this.unhoveredStyle = this.style.cssText;
+        \(styles.map { "this.style.\($0.name) = '\($0.value)'" }.joined(separator: "; "))
+        """
+    }
+}
+
+private struct RemoveHoverEffects: Action {
+    func compile() -> String {
+        """
+        this.style.cssText = this.unhoveredStyle;
+        """
+    }
+}

--- a/Sources/Ignite/Modifiers/Shadow.swift
+++ b/Sources/Ignite/Modifiers/Shadow.swift
@@ -7,6 +7,29 @@
 
 import Foundation
 
+/// A type used to define a box-shadow
+struct Shadow: CustomStringConvertible {
+    /// The shadow's color.
+    let color: Color
+    
+    /// The shadow's radius
+    let radius: Int
+
+    /// The X offset for the shadow, specified in pixels. Defaults to 0.
+    var x: Int = 0
+
+    /// The Y offset for the shadow, specified in pixels. Defaults to 0.
+    var y: Int = 0
+
+    /// Wether the shadow is inset or not
+    var inset = false
+
+    /// The CSS representation of this shadow.
+    var description: String {
+        "\(color) \(x)px \(y)px \(radius)px \(inset == true ? "inset" : "")"
+    }
+}
+
 // X and Y are correct names here.
 // swiftlint:disable identifier_name
 extension BlockElement {
@@ -18,7 +41,8 @@ extension BlockElement {
     ///   - y: The Y offset for the shadow, specified in pixels. Defaults to 0.
     /// - Returns: A copy of this element with the updated shadow applied.
     public func innerShadow(_ color: Color = .black.opacity(0.33), radius: Int, x: Int = 0, y: Int = 0) -> Self {
-        self.style("box-shadow: \(color) \(x)px \(y)px \(radius)px inset")
+        let shadow = Shadow(color: color, radius: radius, x: x, y: y, inset: true)
+        return style("box-shadow: \(shadow)")
     }
 
     /// Applies a drop shadow to this element.
@@ -29,7 +53,8 @@ extension BlockElement {
     ///   - y: The Y offset for the shadow, specified in pixels. Defaults to 0.
     /// - Returns: A copy of this element with the updated shadow applied.
     public func shadow(_ color: Color = .black.opacity(0.33), radius: Int, x: Int = 0, y: Int = 0) -> Self {
-        self.style("box-shadow: \(color) \(x)px \(y)px \(radius)px")
+        let shadow = Shadow(color: color, radius: radius, x: x, y: y, inset: false)
+        return style("box-shadow: \(shadow)")
     }
 }
 // swiftlint:enable identifier_name


### PR DESCRIPTION
This PR adds a show and hide shadow action which can be used to show a box shadow on hovering over an element. This is useful to indicated that it can be clicked, e.g. an image that shows a larger version of itself as a modal. 

To be able to reuse the shadows css representation I introduced a `Shadow` type. I'm not happy about the amount of code this adds but also reuses duplication in the css strings. Let me know what you prefer.

```swift 
Image(decorative: "/images/awesome.jpeg")
        .resizable()
        .frame(width: 150)
        .cornerRadius(6)
        .onHover { isHovering in
            if isHovering {
                ShowBoxShadow()
            } else {
                HideBoxShadow()
            }
        }
        .onClick {
            ShowModal(id: "largeImageModalId")
        }
```