### PR TITLE
Feature / Content Mode for Images alongside Aspect Ratio Modifier

### DIFF
--- a/Sources/Ignite/Modifiers/AspectRatio.swift
+++ b/Sources/Ignite/Modifiers/AspectRatio.swift
@@ -22,6 +22,19 @@ public enum AspectRatio: String {
     case r21x9 = "21x9"
 }
 
+/// The content mode of an element, e.g. an image, within it's container
+public enum ContentMode {
+    /// The element is sized to fit into the container
+    case fit
+
+    /// The element is sized to fill the container, possibly cutting of parts of the element
+    case fill
+
+    var htmlClass: String {
+        "object-fit-\(self == .fill ? "cover" : "contain")"
+    }
+}
+
 extension BlockElement {
     /// Applies a fixed aspect ratio to the current element.
     /// - Parameter ratio: The aspect ratio to apply.
@@ -39,5 +52,31 @@ extension BlockElement {
         return self
             .class("ratio")
             .style("--bs-aspect-ratio: \(percentage)%")
+    }
+}
+
+extension BlockElement where Self == Image {
+    /// Applies a fixed aspect ratio to the image element.
+    /// - Parameters:
+    ///   - ratio: The aspect ratio to apply.
+    ///   - contentMode: The content mode to apply.
+    /// - Returns: A new instance of this element with the ratio and content mode applied.
+    public func aspectRatio(_ ratio: AspectRatio, contentMode: ContentMode) -> some BlockElement {
+        Group {
+            self.class(contentMode.htmlClass)
+        }
+        .aspectRatio(ratio)
+    }
+
+    /// Applies a fixed aspect ratio to the image element.
+    /// - Parameters:
+    ///   - ratio: The ratio to use, relative to 1.
+    ///   - contentMode: The content mode to apply.
+    /// - Returns: A new instance of this element with the ratio and content mode applied.
+    public func aspectRatio(_ ratio: Double, contentMode: ContentMode) -> some BlockElement {
+        Group {
+            self.class(contentMode.htmlClass)
+        }
+        .aspectRatio(ratio)
     }
 }


### PR DESCRIPTION
This PR adds the possibility to control the content mode for images alongside the aspect ratio modifier similar to SwiftUIs API. 

See Issue https://github.com/twostraws/Ignite/issues/89

