### PR TITLE
Make Bootstrap files optional

### DIFF
--- a/Sources/Ignite/Components/FeedLink.swift
+++ b/Sources/Ignite/Components/FeedLink.swift
@@ -14,7 +14,7 @@ struct FeedLink: Component {
     func body(context: PublishingContext) -> [any PageElement] {
         if context.site.isFeedEnabled {
             Text {
-                if context.site.builtInIconsEnabled {
+                if context.site.builtInIconsEnabled != .none {
                     Image(systemName: "rss-fill")
                         .foregroundStyle(Color(hex: "#f26522"))
                         .margin(.trailing, 10)

--- a/Sources/Ignite/Elements/Body.swift
+++ b/Sources/Ignite/Elements/Body.swift
@@ -33,7 +33,9 @@ public struct Body: PageElement, HTMLRootElement {
         .class("col-sm-\(context.site.pageWidth)", "mx-auto")
         .render(context: context)
 
-        output += Script(file: "/js/bootstrap.bundle.min.js").render(context: context)
+        if context.site.useDefaultBootstrapURLS {
+            output += Script(file: "/js/bootstrap.bundle.min.js").render(context: context)
+        }
 
         if context.site.syntaxHighlighters.isEmpty == false {
             output += Script(file: "/js/syntax-highlighting.js").render(context: context)

--- a/Sources/Ignite/Elements/Body.swift
+++ b/Sources/Ignite/Elements/Body.swift
@@ -33,10 +33,15 @@ public struct Body: PageElement, HTMLRootElement {
         .class("col-sm-\(context.site.pageWidth)", "mx-auto")
         .render(context: context)
 
-        if context.site.useDefaultBootstrapURLS {
+        if context.site.useDefaultBootstrapURLs == .localBootstrap {
             output += Script(file: "/js/bootstrap.bundle.min.js").render(context: context)
+        } else if context.site.useDefaultBootstrapURLs == .remoteBootstrap {
+            output += Script(file: "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js")
+                                .addCustomAttribute(name: "integrity", value: "sha384-0pUGZvbkm6XF6gxjEnlmuGrJXVbNuzT9qBBavbLwCsOGabYfZo0T0to5eqruptLy")
+                                .addCustomAttribute(name: "crossorigin", value: "anonymous")
+                                .render(context: context)
         }
-
+        
         if context.site.syntaxHighlighters.isEmpty == false {
             output += Script(file: "/js/syntax-highlighting.js").render(context: context)
         }

--- a/Sources/Ignite/Elements/Head.swift
+++ b/Sources/Ignite/Elements/Head.swift
@@ -71,16 +71,20 @@ public struct Head: HTMLRootElement {
 
         Title(page.title)
         
-        if context.site.useDefaultBootstrapURLS {
+        if context.site.useDefaultBootstrapURLs == .localBootstrap {
             MetaLink.standardCSS
+        } else if context.site.useDefaultBootstrapURLs == .remoteBootstrap {
+            MetaLink.remoteIconCSS
         }
 
         if context.site.syntaxHighlighters.isEmpty == false {
             MetaLink.syntaxHighlightingCSS
         }
-
-        if context.site.builtInIconsEnabled {
+        
+        if context.site.builtInIconsEnabled == .localBootstrap {
             MetaLink.iconCSS
+        } else if context.site.builtInIconsEnabled == .remoteBootstrap {
+            MetaLink.remoteIconCSS
         }
 
         MetaLink(href: page.url, rel: "canonical")

--- a/Sources/Ignite/Elements/Head.swift
+++ b/Sources/Ignite/Elements/Head.swift
@@ -70,8 +70,10 @@ public struct Head: HTMLRootElement {
         MetaTag.generator
 
         Title(page.title)
-
-        MetaLink.standardCSS
+        
+        if context.site.useDefaultBootstrapURLS {
+            MetaLink.standardCSS
+        }
 
         if context.site.syntaxHighlighters.isEmpty == false {
             MetaLink.syntaxHighlightingCSS

--- a/Sources/Ignite/Elements/MetaLink.swift
+++ b/Sources/Ignite/Elements/MetaLink.swift
@@ -12,9 +12,17 @@ import Foundation
 public struct MetaLink: HeadElement {
     /// The standard CSS you should include on all Ignite pages.
     public static let standardCSS = MetaLink(href: "/css/bootstrap.min.css", rel: "stylesheet")
+    
+    /// The standard CSS you should include on all Ignite pages if using remote Bootstrap files
+    public static let standardRemoteCSS = MetaLink(href: "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css", rel: "stylesheet")
+                        .addCustomAttribute(name: "integrity", value: "sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH")
+                        .addCustomAttribute(name: "crossorigin", value: "anonymous")
 
     /// The CSS you should include for Ignite pages that use system icons.
     public static let iconCSS = MetaLink(href: "/css/bootstrap-icons.min.css", rel: "stylesheet")
+    
+    /// The CSS you should include for Ignite pages that use system icons if using Bootstrap from a CDN.
+    public static let remoteIconCSS = MetaLink(href: "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css", rel: "stylesheet")
 
     /// The standard CSS you should include on all pages that use syntax highlighting.
     public static let syntaxHighlightingCSS = MetaLink(href: "/css/prism-default-dark.css", rel: "stylesheet")

--- a/Sources/Ignite/Framework/Site.swift
+++ b/Sources/Ignite/Framework/Site.swift
@@ -52,13 +52,15 @@ public protocol Site {
     /// which allows a little margin on either side.
     var pageWidth: Int { get }
 
-    /// Set to false if you would like to provide all your own Bootstrap (or other CSS/JS links
-    /// instead of using the default generated ones
-    var useDefaultBootstrapURLS: Bool { get }
+    /// Choose whether to use a local version of Boostrap, a remote version,
+    /// or none at all
+    var useDefaultBootstrapURLs: BootstrapOptions { get }
     
-    /// Set to true if you want to use the Bootstrap icon collection on your site.
+    /// Set to `localBootstrap` if you want to use the Bootstrap icon collection on your site.
+    /// and use a local copy of the files or `remoteBootstrap` if you want to use the icon
+    /// collection and load the files from a CDN
     /// Visit https://icons.getbootstrap.com for the full list.
-    var builtInIconsEnabled: Bool { get }
+    var builtInIconsEnabled: BootstrapOptions { get }
 
     /// An array of syntax highlighters you want to enable for your site.
     var syntaxHighlighters: [SyntaxHighlighter] { get }
@@ -118,11 +120,11 @@ extension Site {
     /// desktop browsers where horizontal space is plentiful.
     public var pageWidth: Int { 10 }
     
-    /// Enable Boostrap files by default
-    public var useDefaultBootstrapURLS: Bool { true }
+    /// Enable local Boostrap files by default
+    public var useDefaultBootstrapURLs: BootstrapOptions { .localBootstrap }
 
     /// Disable Bootstrap icons by default.
-    public var builtInIconsEnabled: Bool { false }
+    public var builtInIconsEnabled: BootstrapOptions { .localBootstrap }
 
     /// Include no syntax highlighters by default.
     public var syntaxHighlighters: [SyntaxHighlighter] { [] }

--- a/Sources/Ignite/Framework/Site.swift
+++ b/Sources/Ignite/Framework/Site.swift
@@ -52,6 +52,10 @@ public protocol Site {
     /// which allows a little margin on either side.
     var pageWidth: Int { get }
 
+    /// Set to false if you would like to provide all your own Bootstrap (or other CSS/JS links
+    /// instead of using the default generated ones
+    var useDefaultBootstrapURLS: Bool { get }
+    
     /// Set to true if you want to use the Bootstrap icon collection on your site.
     /// Visit https://icons.getbootstrap.com for the full list.
     var builtInIconsEnabled: Bool { get }
@@ -113,6 +117,9 @@ extension Site {
     /// Use 10 of the 12 available columns by default. Only applies to
     /// desktop browsers where horizontal space is plentiful.
     public var pageWidth: Int { 10 }
+    
+    /// Enable Boostrap files by default
+    public var useDefaultBootstrapURLS: Bool { true }
 
     /// Disable Bootstrap icons by default.
     public var builtInIconsEnabled: Bool { false }

--- a/Sources/Ignite/Publishing/BootstrapOptions.swift
+++ b/Sources/Ignite/Publishing/BootstrapOptions.swift
@@ -1,0 +1,13 @@
+/// Configuration option including a remote or local version of Bootstrap or none at all
+public enum BootstrapOptions {
+    /// Use a local copy of Bootstrap. This will copy Bootstrap's CSS and JavasScript to the
+    /// generated code and add references in the generated pages
+    case localBootstrap
+    /// Use a remote copy of Bootstrap. This will add references to the Bootstrap in the
+    /// generated pages and reference Bootstrap's CDN. Local copies of Boostrap
+    /// will not be copied over
+    case remoteBootstrap
+    /// Don't add any rereferences to Bootstrap in the generated pages and don't copy any
+    /// files over
+    case none
+}

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -189,8 +189,10 @@ public class PublishingContext {
             )
         }
 
-        try copy(resource: "css/bootstrap.min.css")
-        try copy(resource: "js/bootstrap.bundle.min.js")
+        if site.useDefaultBootstrapURLS {
+            try copy(resource: "css/bootstrap.min.css")
+            try copy(resource: "js/bootstrap.bundle.min.js")
+        }
 
         if site.builtInIconsEnabled {
             try copy(resource: "css/bootstrap-icons.min.css")

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -189,12 +189,12 @@ public class PublishingContext {
             )
         }
 
-        if site.useDefaultBootstrapURLS {
+        if site.useDefaultBootstrapURLs == .localBootstrap {
             try copy(resource: "css/bootstrap.min.css")
             try copy(resource: "js/bootstrap.bundle.min.js")
         }
 
-        if site.builtInIconsEnabled {
+        if site.builtInIconsEnabled == .localBootstrap {
             try copy(resource: "css/bootstrap-icons.min.css")
             try copy(resource: "fonts/bootstrap-icons.woff")
             try copy(resource: "fonts/bootstrap-icons.woff2")

--- a/Tests/IgniteTests/TestSite.swift
+++ b/Tests/IgniteTests/TestSite.swift
@@ -14,7 +14,7 @@ struct TestSite: Site {
     var titleSuffix = " - My Test Site"
     var url = URL("https://www.yoursite.com")
 
-    var builtInIconsEnabled = true
+    var builtInIconsEnabled: BootstrapOptions = .localBootstrap
     var syntaxHighlighters = [SyntaxHighlighter.objectiveC]
 
     var homePage = TestPage()

--- a/Tests/IgniteTests/TestSubsite.swift
+++ b/Tests/IgniteTests/TestSubsite.swift
@@ -14,7 +14,7 @@ struct TestSubsite: Site {
     var titleSuffix = " - My Test Subsite"
     var url = URL("https://www.yoursite.com/subsite")
 
-    var builtInIconsEnabled = true
+    var builtInIconsEnabled: BootstrapOptions = .localBootstrap
     var syntaxHighlighters = [SyntaxHighlighter.objectiveC]
 
     var homePage = TestSubsitePage()


### PR DESCRIPTION
Many sites may want control over the bootstrap files that are added, for example:

* Using a pipeline where the CSS is generated by SASS and JS with NPM
* Using GH pages where we need to use the files from the Bootstrap CDN
* Using a different design framework altogether

This PR introduces a new config option, `useDefaultBootstrapURLS`, that can be used to disable the default CSS and JS files for Bootstrap to provide better customisation.