### PR TITLE
Added table with links to website and repository created with Ignite

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ That will launch a local web server you should use to preview your site, and als
 > The Ignite command-line tool has various configuration options available. Run `ignite help` to get general help, or add `help` before a subcommand to get further details, e.g. `ignite help run`.
 
 
+## Websites made with Ignite
+
+[Ignite Websites](https://github.com/jcalderita/Ignite-Websites)
+
 ## Contributing
 
 I welcome all contributions, whether that's adding new tests, fixing up existing code, adding comments, or improving this README – everyone is welcome!


### PR DESCRIPTION
This change includes a link to a repository that only contains a README with a table of websites made with Ignite and its repositories.

I believe that the repositories shared here should share the Ignite project policy and be OpenSource.

Another repository has been created for as discussed in another pull request, so that the current one is not contaminated with many pull requests.

The ownership of this new repository should still be @twostraws 

Whatever is decided.