### PR TITLE
Fix image duplication in Card

### DIFF
--- a/Sources/Ignite/Elements/Card.swift
+++ b/Sources/Ignite/Elements/Card.swift
@@ -217,7 +217,7 @@ public struct Card: BlockElement {
 
             renderItems()
 
-            if let image, contentPosition.addImageFirst {
+            if let image, !contentPosition.addImageFirst {
                 if imageOpacity != 1 {
                     image
                         .class(contentPosition.imageClass)


### PR DESCRIPTION
Image was currently rendered first and also after items before footer. This will revert back the change brought by last code update.