### PR TITLE
Update CoreAttributes.swift

### DIFF
--- a/Sources/Ignite/Styles/CoreAttributes.swift
+++ b/Sources/Ignite/Styles/CoreAttributes.swift
@@ -77,7 +77,7 @@ public struct CoreAttributes: Sendable {
             return ""
         } else {
             let stringified = styles.map { "\($0.name): \($0.value)" }.joined(separator: "; ")
-            return "style=\"\(stringified)\""
+            return " style=\"\(stringified)\""
         }
     }
 


### PR DESCRIPTION
custom styles were not distinguished from heading, and was failing upon build. Restored space.