### PR TITLE
added specific versioning for swift-markdown

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .executable(name: "IgniteCLI", targets: ["IgniteCLI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-markdown.git", branch: "main"),
+        .package(url: "https://github.com/swiftlang/swift-markdown.git", from: "0.5.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0")
     ],
     targets: [


### PR DESCRIPTION
Swift-Markdown recently started cutting versions. I decided to go ahead and update the package definition to use the new versions, allowing Ignite to be built inside of an existing project.

More details here: https://github.com/swiftlang/swift-markdown/issues/178#issuecomment-2177095161