### PR TITLE
Ensure soft breaks in Markdown result in spaces in the resulting HTML

### DIFF
--- a/Sources/Ignite/Rendering/Markdown/MarkdownToHTML.swift
+++ b/Sources/Ignite/Rendering/Markdown/MarkdownToHTML.swift
@@ -129,6 +129,13 @@ public struct MarkdownToHTML: MarkdownRenderer, MarkupVisitor {
         }
     }
 
+    /// Processes soft breaks (single newlines).
+    /// - Parameter softBreak: The soft break to process.
+    /// - Returns: A single space.
+    public func visitSoftBreak(_ softBreak: SoftBreak) -> String {
+        return " "
+    }
+
     /// Processes emphasis markup.
     /// - Parameter emphasis: The emphasized content to process.
     /// - Returns: A HTML <em> element with the markup's children inside.

--- a/Tests/IgniteTests/Elements/Text.swift
+++ b/Tests/IgniteTests/Elements/Text.swift
@@ -69,4 +69,12 @@ final class TextTests: ElementTest {
         XCTAssertEqual(output, "<p>Text in <em>italics</em>, text in <strong>bold</strong>, and text in <em><strong>bold italics</strong></em>.</p>")
         // swiftlint:enable line_length
     }
+
+    func test_markdownSoftBreaks() {
+        let element = Text(markdown: "This is a single\nline of markdown with a soft break")
+        let output = element.render(context: publishingContext)
+        // swiftlint:disable line_length
+        XCTAssertEqual(output, "<p>This is a single line of markdown with a soft break</p>")
+        // swiftlint:enable line_length
+    }
 }

--- a/Tests/IgniteTests/IgniteTests.swift
+++ b/Tests/IgniteTests/IgniteTests.swift
@@ -6,10 +6,8 @@ import XCTest
 class ElementTest: XCTestCase {
 
     /// A publishing context with sample values for root site tests.
-    let publishingContext = try! PublishingContext(for: TestSite(),
-                                                   rootURL: URL.documentsDirectory)
+    let publishingContext = try! PublishingContext(for: TestSite(), from: #file)
     /// A publishing context with sample values for subsite tests.
-    let publishingSubsiteContext = try! PublishingContext(for: TestSubsite(),
-                                                          rootURL: URL.documentsDirectory)
+    let publishingSubsiteContext = try! PublishingContext(for: TestSubsite(), from: #file)
 }
 // swiftlint:enable force_try


### PR DESCRIPTION
When Markdown is wrapped to line limits, newlines in the markdown result in a soft break. This break should expand to a single space, and two newlines result in a proper newline.

This fixes the MarkdownToHTML generation to ensure soft breaks are spaced properly.

This also fixes a build error in the tests.