### PR TITLE
Fix URL init compiler error

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Once you've defined a custom layout, you should add it to your `Site` struct. Th
 ```swift
 struct ExampleSite: Site {    
     var name = "Hello World"
-    var url: URL = URL("https://www.example.com")
+    var url = URL(static: "https://www.example.com")
 
     var homePage = Home()
     var theme = MyTheme()

--- a/Sources/Ignite/Components/IgniteFooter.swift
+++ b/Sources/Ignite/Components/IgniteFooter.swift
@@ -15,7 +15,7 @@ public struct IgniteFooter: HTML {
     public var body: some HTML {
         Text {
             "Created with "
-            Link("Ignite", target: URL("https://github.com/twostraws/Ignite"))
+            Link("Ignite", target: URL(static: "https://github.com/twostraws/Ignite"))
         }
         .horizontalAlignment(.center)
         .margin(.top, .extraLarge)

--- a/Sources/Ignite/Extensions/URL-Unwrapped.swift
+++ b/Sources/Ignite/Extensions/URL-Unwrapped.swift
@@ -10,7 +10,7 @@ import Foundation
 extension URL {
     /// Creates URLs from static strings, which will only fail if you have made
     /// a significant typing error.
-    public init(_ string: StaticString) {
+    public init(static string: StaticString) {
         if let created = URL(string: String(describing: string)) {
             self = created
         } else {

--- a/Sources/Ignite/Publishing/SiteConfiguration.swift
+++ b/Sources/Ignite/Publishing/SiteConfiguration.swift
@@ -74,7 +74,7 @@ public struct SiteConfiguration: Sendable {
         self.titleSuffix = ""
         self.description = ""
         self.language = .english
-        self.url = URL("https://example.com")
+        self.url = URL(static: "https://example.com")
         self.useDefaultBootstrapURLs = .localBootstrap
         self.builtInIconsEnabled = .localBootstrap
         self.syntaxHighlighters = []

--- a/Tests/IgniteTests/NonRoot Elements/SubsiteBody.swift
+++ b/Tests/IgniteTests/NonRoot Elements/SubsiteBody.swift
@@ -12,7 +12,7 @@ import XCTest
 @MainActor final class SubsiteBodyTests: ElementTest {
     func test_body_simple() {
         let element = HTMLBody(for: Page(title: "TITLE", description: "DESCRIPTION",
-                                         url: URL("http://www.yoursite.com/subsite"),
+                                         url: URL(static: "http://www.yoursite.com/subsite"),
                                          body: Text("TEXT")))
         let output = element.render(context: publishingSubsiteContext)
 

--- a/Tests/IgniteTests/TestSite.swift
+++ b/Tests/IgniteTests/TestSite.swift
@@ -12,7 +12,7 @@ import Ignite
 struct TestSite: Site {
     var name = "My Test Site"
     var titleSuffix = " - My Test Site"
-    var url: URL = .init("https://www.yoursite.com")
+    var url = URL(static: "https://www.yoursite.com")
 
     var builtInIconsEnabled: BootstrapOptions = .localBootstrap
     var syntaxHighlighters = [SyntaxHighlighter.objectiveC]

--- a/Tests/IgniteTests/TestSubsite.swift
+++ b/Tests/IgniteTests/TestSubsite.swift
@@ -12,7 +12,7 @@ import Ignite
 struct TestSubsite: Site {
     var name = "My Test Subsite"
     var titleSuffix = " - My Test Subsite"
-    var url: URL = .init("https://www.yoursite.com/subsite")
+    var url = URL(static: "https://www.yoursite.com/subsite")
 
     var builtInIconsEnabled: BootstrapOptions = .localBootstrap
     var syntaxHighlighters = [SyntaxHighlighter.objectiveC]


### PR DESCRIPTION
Compiler error when initializing the URL, which occurs because the project has an URL extension(file URL-Unwrapped.swift) that conflicts with Foundation’s initializer signature.
<img width="656" alt="Screenshot 2024-11-15 at 3 14 33 AM" src="https://github.com/user-attachments/assets/30f81479-c0e5-420a-bbba-3b5f5c5e9a0c">
Fixed extension, files using it and tests. Sample project will be fixed after merge.
This error can also be fixed by force-unwrapping the URL. Since the project has no runtime, and if the url is incorrect, a crash will occur during the build. In this case extension will be deleted.