### PR TITLE
Add part of SpotifyContentType

### DIFF
--- a/Sources/Ignite/Elements/Embed.swift
+++ b/Sources/Ignite/Elements/Embed.swift
@@ -15,6 +15,14 @@ public struct Embed: BlockElement, LazyLoadable {
         case track
         /// Creates interactive  item for a Spotify playlist
         case playlist
+        /// Create interactive item for a Spotify artist
+        case artist
+        /// Creates interactive item for a Spotify album
+        case album
+        /// Creates interactive item for a Spotify podcast
+        case show
+        /// Creates interactive item for a Spotify episode
+        case episode
     }
 
     /// The content and behavior of this HTML.


### PR DESCRIPTION
# Over View
Add SpotifyContentType
- artist
- album
- show
- episode

show, episode is used in PodCast.

<img width="637" alt="スクリーンショット 2024-11-25 0 35 39" src="https://github.com/user-attachments/assets/e6bf8296-dcdf-4214-9944-0a4af3540f03">
