### PR TITLE
Make FeedLink public.

### DIFF
--- a/Sources/Ignite/Components/FeedLink.swift
+++ b/Sources/Ignite/Components/FeedLink.swift
@@ -6,12 +6,12 @@
 //
 
 /// Displays a link to your RSS feed, if enabled.
-struct FeedLink: HTML {
+public struct FeedLink: HTML {
 
     @Environment(\.siteConfiguration) private var siteConfig
     @Environment(\.feedConfiguration) private var feedConfig
 
-    var body: some HTML {
+    public var body: some HTML {
         Text {
             if siteConfig.builtInIconsEnabled != .none {
                 Image(systemName: "rss-fill")


### PR DESCRIPTION
Make the FeedLink component public so that it may be used by Ignite clients.