### PR TITLE
Add support for Markdown hard line breaks

### DIFF
--- a/Sources/Ignite/Rendering/Markdown/MarkdownToHTML.swift
+++ b/Sources/Ignite/Rendering/Markdown/MarkdownToHTML.swift
@@ -135,6 +135,13 @@ public struct MarkdownToHTML: MarkdownRenderer, MarkupVisitor {
         return " "
     }
 
+    /// Processes hard line breaks (lines ending with 2 spaces or a backslash).
+    /// - Parameter lineBreak: The line break to process.
+    /// - Returns: A HTML <br /> tag.
+    public func visitLineBreak(_ lineBreak: LineBreak) -> String {
+        return "<br />"
+    }
+
     /// Processes emphasis markup.
     /// - Parameter emphasis: The emphasized content to process.
     /// - Returns: A HTML <em> element with the markup's children inside.

--- a/Tests/IgniteTests/Elements/Text.swift
+++ b/Tests/IgniteTests/Elements/Text.swift
@@ -77,4 +77,18 @@ import XCTest
         XCTAssertEqual(output, "<p>This is a single line of markdown with a soft break</p>")
         // swiftlint:enable line_length
     }
+
+    func test_markdownHardBreaks() {
+        let markdown =
+        """
+        This is line 1  
+        This is line 2  
+        This is line 3  
+        """
+        let element = Text(markdown: markdown)
+        let output = element.render(context: publishingContext)
+        // swiftlint:disable line_length
+        XCTAssertEqual(output, "<p>This is line 1<br />This is line 2<br />This is line 3</p>")
+        // swiftlint:enable line_length
+    }
 }


### PR DESCRIPTION
Ensure a line break in Markdown (not in a code span or HTML tag) that is preceded by two or more spaces and does not occur at the end of a block is parsed as a hard line break (rendered in HTML as a <br /> tag).