### PR TITLE
Replace #file with #filePath in IgniteTests.swift

### DIFF
--- a/Tests/IgniteTests/IgniteTests.swift
+++ b/Tests/IgniteTests/IgniteTests.swift
@@ -12,9 +12,9 @@ import XCTest
 /// A base class that sets up an example publishing context for testing purposes.
 @MainActor class ElementTest: XCTestCase {
     /// A publishing context with sample values for root site tests.
-    let publishingContext = try! PublishingContext(for: TestSite(), from: #file)
+    let publishingContext = try! PublishingContext(for: TestSite(), from: #filePath)
     /// A publishing context with sample values for subsite tests.
-    let publishingSubsiteContext = try! PublishingContext(for: TestSubsite(), from: #file)
+    let publishingSubsiteContext = try! PublishingContext(for: TestSubsite(), from: #filePath)
 }
 
 // swiftlint:enable force_try


### PR DESCRIPTION
This PR addresses the `Ignite.PublishingError.missingPackageDirectory` error that occurred in `IgniteTests.swift` when using `#file` by replacing it with `#filePath`.