### PR TITLE
Fix font application

### DIFF
--- a/Sources/Ignite/Modifiers/ModifiedHTML.swift
+++ b/Sources/Ignite/Modifiers/ModifiedHTML.swift
@@ -35,7 +35,7 @@ struct ModifiedHTML: HTML, InlineHTML, BlockHTML, RootHTML, NavigationItem {
             AttributeStore.default.merge(content.attributes, intoHTML: id)
         }
 
-        let modifiedContent: any HTML = modifier.body(content: self)
+        _ = modifier.body(content: content)
 
         AttributeStore.default.merge(content.attributes, intoHTML: id)
 

--- a/Tests/IgniteTests/IgniteTests.swift
+++ b/Tests/IgniteTests/IgniteTests.swift
@@ -12,9 +12,9 @@ import XCTest
 /// A base class that sets up an example publishing context for testing purposes.
 @MainActor class ElementTest: XCTestCase {
     /// A publishing context with sample values for root site tests.
-    let publishingContext = try! PublishingContext(for: TestSite(), from: #file)
+    let publishingContext = try! PublishingContext(for: TestSite(), from: #filePath)
     /// A publishing context with sample values for subsite tests.
-    let publishingSubsiteContext = try! PublishingContext(for: TestSubsite(), from: #file)
+    let publishingSubsiteContext = try! PublishingContext(for: TestSubsite(), from: #filePath)
 }
 
 // swiftlint:enable force_try


### PR DESCRIPTION
This issue is detected by the `test_customFont` test when the #179 PR is applied. By modifying an underlying HTML content within the `ModifiedHTML`, the modifier `FontStyleModifier` can find the text content and apply required style.

These changes are proposed based on the assumption that `ModifiedHTML` need to modify underlying HTML content rather than itself (`FontStyleModifier` expects `content.body` to be `Text`). However, I can be mistaken because it contradicts to the merged #174 changes. Please let me know what you think.