### PR TITLE
Remove `ListableElement` conformance from `ForEach`...

### DIFF
--- a/Sources/Ignite/Framework/ElementTypes/HTML.swift
+++ b/Sources/Ignite/Framework/ElementTypes/HTML.swift
@@ -318,6 +318,10 @@ public extension HTML {
     }
 }
 
+
+/// Recursively flattens nested `InlineHTML` content into a single array, unwrapping any body properties.
+/// - Parameter content: The content to flatten and unwrap
+/// - Returns: An array of unwrapped `InlineHTML` elements
 @MainActor func flatUnwrap(_ content: Any) -> [any InlineHTML] {
     if let array = content as? [Any] {
         array.flatMap { flatUnwrap($0) }

--- a/Sources/Ignite/Framework/ForEach.swift
+++ b/Sources/Ignite/Framework/ForEach.swift
@@ -6,7 +6,7 @@
 //
 
 /// A structure that creates HTML content by mapping over a sequence of data.
-public struct ForEach<Data: Sequence, Content: HTML>: InlineHTML, BlockHTML, ListableElement {
+public struct ForEach<Data: Sequence, Content: HTML>: InlineHTML, BlockHTML {
     /// The body content created by mapping over the data sequence.
     public var body: some HTML { self }
 


### PR DESCRIPTION
Remove `ListableElement` conformance from `ForEach` to fix empty `<li>` tags.