### PR TITLE
Decouple passthrough and container variants of `Group` into `Group` and `GroupBox`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ struct CustomContentLayout: ContentLayout {
         }
 
         if content.hasTags {
-            Group {
+            GroupBox {
                 Text("Tagged with: \(content.tags.joined(separator: ", "))")
 
                 Text("\(content.estimatedWordCount) words; \(content.estimatedReadingMinutes) minutes to read.")

--- a/Sources/Ignite/Elements/Accordion.swift
+++ b/Sources/Ignite/Elements/Accordion.swift
@@ -63,7 +63,7 @@ public struct Accordion: BlockHTML {
         // items so they can adapt accordinly.
         let accordionID = "accordion\(UUID().uuidString.truncatedHash)"
         let assignedItems = items.map { $0.assigned(to: accordionID, openMode: openMode) }
-        let output = Group { assignedItems }
+        let output = GroupBox { assignedItems }
             .attributes(attributes)
             .class("accordion")
             .id(accordionID)

--- a/Sources/Ignite/Elements/Accordion.swift
+++ b/Sources/Ignite/Elements/Accordion.swift
@@ -63,7 +63,7 @@ public struct Accordion: BlockHTML {
         // items so they can adapt accordinly.
         let accordionID = "accordion\(UUID().uuidString.truncatedHash)"
         let assignedItems = items.map { $0.assigned(to: accordionID, openMode: openMode) }
-        let output = GroupBox { assignedItems }
+        let output = Container { assignedItems }
             .attributes(attributes)
             .class("accordion")
             .id(accordionID)

--- a/Sources/Ignite/Elements/ButtonGroup.swift
+++ b/Sources/Ignite/Elements/ButtonGroup.swift
@@ -44,7 +44,7 @@ public struct ButtonGroup: BlockHTML {
     /// - Parameter context: The current publishing context.
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
-        Group {
+        GroupBox {
             content.map { $0.render(context: context) }.joined()
         }
         .class("btn-group")

--- a/Sources/Ignite/Elements/ButtonGroup.swift
+++ b/Sources/Ignite/Elements/ButtonGroup.swift
@@ -44,7 +44,7 @@ public struct ButtonGroup: BlockHTML {
     /// - Parameter context: The current publishing context.
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
-        GroupBox {
+        Container {
             content.map { $0.render(context: context) }.joined()
         }
         .class("btn-group")

--- a/Sources/Ignite/Elements/Card.swift
+++ b/Sources/Ignite/Elements/Card.swift
@@ -207,7 +207,7 @@ public struct Card: BlockHTML {
     }
 
     public func render(context: PublishingContext) -> String {
-        Group {
+        GroupBox {
             if let image, contentPosition.addImageFirst {
                 if imageOpacity != 1 {
                     image
@@ -246,8 +246,8 @@ public struct Card: BlockHTML {
         .render(context: context)
     }
 
-    private func renderHeader() -> Group {
-        Group {
+    private func renderHeader() -> GroupBox {
+        GroupBox {
             for item in header {
                 item
             }
@@ -255,8 +255,8 @@ public struct Card: BlockHTML {
         .class("card-header")
     }
 
-    private func renderItems() -> Group {
-        Group {
+    private func renderItems() -> GroupBox {
+        GroupBox {
             ForEach(items) { item in
                 switch item {
                 case let text as Text where text.font == .body || text.font == .lead:
@@ -275,8 +275,8 @@ public struct Card: BlockHTML {
         .class(contentPosition.bodyClasses)
     }
 
-    private func renderFooter() -> Group {
-        Group {
+    private func renderFooter() -> GroupBox {
+        GroupBox {
             for item in footer {
                 item
             }

--- a/Sources/Ignite/Elements/Card.swift
+++ b/Sources/Ignite/Elements/Card.swift
@@ -207,7 +207,7 @@ public struct Card: BlockHTML {
     }
 
     public func render(context: PublishingContext) -> String {
-        GroupBox {
+        Container {
             if let image, contentPosition.addImageFirst {
                 if imageOpacity != 1 {
                     image
@@ -246,8 +246,8 @@ public struct Card: BlockHTML {
         .render(context: context)
     }
 
-    private func renderHeader() -> GroupBox {
-        GroupBox {
+    private func renderHeader() -> Container {
+        Container {
             for item in header {
                 item
             }
@@ -255,8 +255,8 @@ public struct Card: BlockHTML {
         .class("card-header")
     }
 
-    private func renderItems() -> GroupBox {
-        GroupBox {
+    private func renderItems() -> Container {
+        Container {
             ForEach(items) { item in
                 switch item {
                 case let text as Text where text.font == .body || text.font == .lead:
@@ -275,8 +275,8 @@ public struct Card: BlockHTML {
         .class(contentPosition.bodyClasses)
     }
 
-    private func renderFooter() -> GroupBox {
-        GroupBox {
+    private func renderFooter() -> Container {
+        Container {
             for item in footer {
                 item
             }

--- a/Sources/Ignite/Elements/Carousel.swift
+++ b/Sources/Ignite/Elements/Carousel.swift
@@ -58,8 +58,8 @@ public struct Carousel: BlockHTML {
     /// - Parameter context: The current publishing context.
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
-        Group {
-            Group {
+        GroupBox {
+            GroupBox {
                 ForEach(0..<items.count) { index in
                     Button()
                         .data("bs-target", "#\(carouselID)")
@@ -71,7 +71,7 @@ public struct Carousel: BlockHTML {
             }
             .class("carousel-indicators")
 
-            Group {
+            GroupBox {
                 ForEach(items.enumerated()) { index, item in
                     item.assigned(at: index, in: context)
                 }

--- a/Sources/Ignite/Elements/Carousel.swift
+++ b/Sources/Ignite/Elements/Carousel.swift
@@ -58,8 +58,8 @@ public struct Carousel: BlockHTML {
     /// - Parameter context: The current publishing context.
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
-        GroupBox {
-            GroupBox {
+        Container {
+            Container {
                 ForEach(0..<items.count) { index in
                     Button()
                         .data("bs-target", "#\(carouselID)")
@@ -71,7 +71,7 @@ public struct Carousel: BlockHTML {
             }
             .class("carousel-indicators")
 
-            GroupBox {
+            Container {
                 ForEach(items.enumerated()) { index, item in
                     item.assigned(at: index, in: context)
                 }

--- a/Sources/Ignite/Elements/Container.swift
+++ b/Sources/Ignite/Elements/Container.swift
@@ -5,7 +5,15 @@
 // See LICENSE for license information.
 //
 
-public struct GroupBox: BlockHTML {
+/// A container element that wraps its children in a `div` element.
+///
+/// Use `Container` when you want to group elements together and have them rendered
+/// within a containing HTML `div`. This is useful for applying shared styling,
+/// creating layout structures, or logically grouping related content.
+///
+/// - Note: Unlike ``Group``, modifiers applied to a `Container` affect the
+///         containing `div` element rather than being propagated to child elements.
+public struct Container: BlockHTML {
     /// The content and behavior of this HTML.
     public var body: some HTML { self }
 
@@ -19,32 +27,23 @@ public struct GroupBox: BlockHTML {
     public var columnWidth = ColumnWidth.automatic
 
     var items: [any HTML] = []
-    private var backgroundColor: Color?
 
-    public init(background: Color? = nil, @HTMLBuilder content: () -> some HTML) {
+    public init(@HTMLBuilder content: () -> some HTML) {
         self.items = flatUnwrap(content())
-        self.backgroundColor = background
     }
 
     public init(_ items: any HTML, background: Color? = nil) {
         self.items = flatUnwrap(items)
-        self.backgroundColor = background
     }
 
     init(context: PublishingContext, items: [any HTML]) {
         self.items = flatUnwrap(items)
-        self.backgroundColor = nil
     }
 
     public func render(context: PublishingContext) -> String {
         let content = items.map { $0.render(context: context) }.joined()
         var attributes = attributes
         attributes.tag = "div"
-
-        if let backgroundColor {
-            attributes.append(styles: .init(name: "background-color", value: backgroundColor.description))
-        }
-
         return attributes.description(wrapping: content)
     }
 }

--- a/Sources/Ignite/Elements/ContentPreview.swift
+++ b/Sources/Ignite/Elements/ContentPreview.swift
@@ -77,7 +77,7 @@ public struct ContentPreview: BlockHTML {
             let tagLinks = content.tagLinks()
 
             if tagLinks.isEmpty == false {
-                GroupBox {
+                Container {
                     tagLinks
                 }
                 .style("margin-top: -5px")

--- a/Sources/Ignite/Elements/ContentPreview.swift
+++ b/Sources/Ignite/Elements/ContentPreview.swift
@@ -77,7 +77,7 @@ public struct ContentPreview: BlockHTML {
             let tagLinks = content.tagLinks()
 
             if tagLinks.isEmpty == false {
-                Group {
+                GroupBox {
                     tagLinks
                 }
                 .style("margin-top: -5px")

--- a/Sources/Ignite/Elements/Dropdown.swift
+++ b/Sources/Ignite/Elements/Dropdown.swift
@@ -94,7 +94,7 @@ public struct Dropdown: BlockHTML, NavigationItem {
                 .class("dropdown")
                 .render(context: context)
         } else {
-            return GroupBox(content)
+            return Container(content)
                 .attributes(attributes)
                 .class("dropdown")
                 .render(context: context)

--- a/Sources/Ignite/Elements/Dropdown.swift
+++ b/Sources/Ignite/Elements/Dropdown.swift
@@ -87,7 +87,25 @@ public struct Dropdown: BlockHTML, NavigationItem {
     /// - Parameter context: The current publishing context.
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
-        Group(isTransparent: isNavigationItem) {
+        let content = renderDropdownContent(context: context)
+        if isNavigationItem {
+            return Group(content)
+                .attributes(attributes)
+                .class("dropdown")
+                .render(context: context)
+        } else {
+            return GroupBox(content)
+                .attributes(attributes)
+                .class("dropdown")
+                .render(context: context)
+        }
+    }
+
+    /// Creates the internal dropdown structure including the trigger button and menu items.
+    /// - Parameter context: The current publishing context.
+    /// - Returns: A group containing the dropdown's trigger and menu list.
+    private func renderDropdownContent(context: PublishingContext) -> some HTML {
+        Group {
             if isNavigationItem {
                 let hasActiveItem = items.contains { context.currentRenderingPath == ($0 as? Link)?.url }
 
@@ -122,8 +140,5 @@ public struct Dropdown: BlockHTML, NavigationItem {
             .listMarkerStyle(.unordered(.automatic))
             .class("dropdown-menu")
         }
-        .attributes(attributes)
-        .class("dropdown")
-        .render(context: context)
     }
 }

--- a/Sources/Ignite/Elements/Embed.swift
+++ b/Sources/Ignite/Elements/Embed.swift
@@ -120,7 +120,7 @@ public struct Embed: BlockHTML, LazyLoadable {
             """)
         }
 
-        return Group {
+        return GroupBox {
              #"<iframe src="\#(url)" title="\#(title)" allow="\#(allowPermissions)"></iframe>"#
         }
         .attributes(attributes)

--- a/Sources/Ignite/Elements/Embed.swift
+++ b/Sources/Ignite/Elements/Embed.swift
@@ -120,7 +120,7 @@ public struct Embed: BlockHTML, LazyLoadable {
             """)
         }
 
-        return GroupBox {
+        return Container {
              #"<iframe src="\#(url)" title="\#(title)" allow="\#(allowPermissions)"></iframe>"#
         }
         .attributes(attributes)

--- a/Sources/Ignite/Elements/Group.swift
+++ b/Sources/Ignite/Elements/Group.swift
@@ -5,6 +5,17 @@
 // See LICENSE for license information.
 //
 
+/// A transparent grouping construct that propagates modifiers to its children.
+///
+/// Use `Group` when you want to apply shared modifiers to multiple elements
+/// without introducing additional HTML structure. Unlike ``Container``, `Group`
+/// doesn't wrap its children in a `div`; instead, it passes modifiers through
+/// to each child element.
+///
+/// - Note: `Group` is particularly useful for applying shared styling or
+///         attributes to multiple elements without affecting the document
+///         structure. If you need a containing `div` element, use
+///         ``Container`` instead.
 public struct Group: BlockHTML {
     /// The content and behavior of this HTML.
     public var body: some HTML { self }

--- a/Sources/Ignite/Elements/GroupBox.swift
+++ b/Sources/Ignite/Elements/GroupBox.swift
@@ -1,11 +1,11 @@
 //
-// Group.swift
+// GroupBox.swift
 // Ignite
 // https://www.github.com/twostraws/Ignite
 // See LICENSE for license information.
 //
 
-public struct Group: BlockHTML {
+public struct GroupBox: BlockHTML {
     /// The content and behavior of this HTML.
     public var body: some HTML { self }
 
@@ -19,24 +19,32 @@ public struct Group: BlockHTML {
     public var columnWidth = ColumnWidth.automatic
 
     var items: [any HTML] = []
+    private var backgroundColor: Color?
 
-    public init(@HTMLBuilder _ content: () -> some HTML) {
+    public init(background: Color? = nil, @HTMLBuilder content: () -> some HTML) {
         self.items = flatUnwrap(content())
+        self.backgroundColor = background
     }
 
-    public init(_ items: any HTML) {
+    public init(_ items: any HTML, background: Color? = nil) {
         self.items = flatUnwrap(items)
+        self.backgroundColor = background
     }
 
     init(context: PublishingContext, items: [any HTML]) {
         self.items = flatUnwrap(items)
+        self.backgroundColor = nil
     }
 
     public func render(context: PublishingContext) -> String {
-        return items.map {
-            let item: any HTML = $0
-            AttributeStore.default.merge(attributes, intoHTML: item.id)
-            return item.render(context: context)
-        }.joined()
+        let content = items.map { $0.render(context: context) }.joined()
+        var attributes = attributes
+        attributes.tag = "div"
+
+        if let backgroundColor {
+            attributes.append(styles: .init(name: "background-color", value: backgroundColor.description))
+        }
+
+        return attributes.description(wrapping: content)
     }
 }

--- a/Sources/Ignite/Elements/Item.swift
+++ b/Sources/Ignite/Elements/Item.swift
@@ -70,7 +70,7 @@ public struct Item: HTML {
 
         let itemID = "\(parentID)-item\(UUID().uuidString.truncatedHash)"
 
-        return GroupBox {
+        return Container {
             Text {
                 Button(title)
                     .class("accordion-button", startsOpen ? "" : "collapsed")
@@ -82,8 +82,8 @@ public struct Item: HTML {
             .font(.title2)
             .class("accordion-header")
 
-            GroupBox {
-                GroupBox {
+            Container {
+                Container {
                     contents.render(context: context)
                 }
                 .class("accordion-body")

--- a/Sources/Ignite/Elements/Item.swift
+++ b/Sources/Ignite/Elements/Item.swift
@@ -70,7 +70,7 @@ public struct Item: HTML {
 
         let itemID = "\(parentID)-item\(UUID().uuidString.truncatedHash)"
 
-        return Group {
+        return GroupBox {
             Text {
                 Button(title)
                     .class("accordion-button", startsOpen ? "" : "collapsed")
@@ -82,8 +82,8 @@ public struct Item: HTML {
             .font(.title2)
             .class("accordion-header")
 
-            Group {
-                Group {
+            GroupBox {
+                GroupBox {
                     contents.render(context: context)
                 }
                 .class("accordion-body")

--- a/Sources/Ignite/Elements/Modal.swift
+++ b/Sources/Ignite/Elements/Modal.swift
@@ -127,23 +127,23 @@ public struct Modal: HTML {
     /// - Parameter context: The current publishing context.
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
-        GroupBox {
-            GroupBox {
-                GroupBox {
+        Container {
+            Container {
+                Container {
                     if !header.isEmptyHTML {
-                        GroupBox {
+                        Container {
                             header
                         }
                         .class("modal-header")
                     }
 
-                    GroupBox {
+                    Container {
                         items
                     }
                     .class("modal-body")
 
                     if !footer.isEmptyHTML {
-                        GroupBox {
+                        Container {
                             footer
                         }
                         .class("modal-footer")

--- a/Sources/Ignite/Elements/Modal.swift
+++ b/Sources/Ignite/Elements/Modal.swift
@@ -127,23 +127,23 @@ public struct Modal: HTML {
     /// - Parameter context: The current publishing context.
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
-        Group {
-            Group {
-                Group {
+        GroupBox {
+            GroupBox {
+                GroupBox {
                     if !header.isEmptyHTML {
-                        Group {
+                        GroupBox {
                             header
                         }
                         .class("modal-header")
                     }
 
-                    Group {
+                    GroupBox {
                         items
                     }
                     .class("modal-body")
 
                     if !footer.isEmptyHTML {
-                        Group {
+                        GroupBox {
                             footer
                         }
                         .class("modal-footer")

--- a/Sources/Ignite/Elements/NavigationBar.swift
+++ b/Sources/Ignite/Elements/NavigationBar.swift
@@ -159,7 +159,7 @@ public struct NavigationBar: BlockHTML {
     public func render(context: PublishingContext) -> String {
         Tag("header") {
             Tag("nav") {
-                GroupBox {
+                Container {
                     if let logo {
                         Link(logo, target: "/")
                             .class("navbar-brand")
@@ -189,8 +189,8 @@ public struct NavigationBar: BlockHTML {
         .aria("label", "Toggle navigation")
     }
 
-    private func renderNavItems(context: PublishingContext) -> GroupBox {
-        GroupBox {
+    private func renderNavItems(context: PublishingContext) -> Container {
+        Container {
             List {
                 ForEach(items) { item in
                     if let dropdownItem = item as? Dropdown {

--- a/Sources/Ignite/Elements/NavigationBar.swift
+++ b/Sources/Ignite/Elements/NavigationBar.swift
@@ -159,7 +159,7 @@ public struct NavigationBar: BlockHTML {
     public func render(context: PublishingContext) -> String {
         Tag("header") {
             Tag("nav") {
-                Group {
+                GroupBox {
                     if let logo {
                         Link(logo, target: "/")
                             .class("navbar-brand")
@@ -189,8 +189,8 @@ public struct NavigationBar: BlockHTML {
         .aria("label", "Toggle navigation")
     }
 
-    private func renderNavItems(context: PublishingContext) -> Group {
-        Group {
+    private func renderNavItems(context: PublishingContext) -> GroupBox {
+        GroupBox {
             List {
                 ForEach(items) { item in
                     if let dropdownItem = item as? Dropdown {

--- a/Sources/Ignite/Elements/Section.swift
+++ b/Sources/Ignite/Elements/Section.swift
@@ -84,7 +84,7 @@ public struct Section: BlockHTML {
             }
         }
 
-        return Group {
+        return GroupBox {
             ForEach(items) { item in
                 if let group = item as? Group {
                     handleGroup(group, attributes: group.attributes)
@@ -92,7 +92,7 @@ public struct Section: BlockHTML {
                           let group = modified.content as? Group {
                     handleGroup(group, attributes: modified.attributes)
                 } else if let item = item as? any BlockHTML {
-                    Group(item)
+                    GroupBox(item)
                         .class(className(for: item))
                         .class(gutterClass)
                 } else {
@@ -117,7 +117,7 @@ public struct Section: BlockHTML {
         }
         return ForEach(group.items) { item in
             if let item = item as? any BlockHTML {
-                Group(item)
+                GroupBox(item)
                     .class(className(for: group))
                     .class(gutterClass)
                     .attributes(attributes)

--- a/Sources/Ignite/Elements/Section.swift
+++ b/Sources/Ignite/Elements/Section.swift
@@ -94,7 +94,7 @@ public struct Section: BlockHTML {
             }
         }
 
-        return GroupBox {
+        return Container {
             ForEach(items) { item in
                 if let group = item as? Group {
                     handleGroup(group, attributes: group.attributes)
@@ -102,7 +102,7 @@ public struct Section: BlockHTML {
                           let group = modified.content as? Group {
                     handleGroup(group, attributes: modified.attributes)
                 } else if let item = item as? any BlockHTML {
-                    GroupBox(item)
+                    Container(item)
                         .class(className(for: item))
                         .class(gutterClass)
                 } else {
@@ -127,7 +127,7 @@ public struct Section: BlockHTML {
         }
         return ForEach(group.items) { item in
             if let item = item as? any BlockHTML {
-                GroupBox(item)
+                Container(item)
                     .class(className(for: group))
                     .class(gutterClass)
                     .attributes(attributes)

--- a/Sources/Ignite/Elements/Slide.swift
+++ b/Sources/Ignite/Elements/Slide.swift
@@ -65,15 +65,15 @@ public struct Slide: BlockHTML {
     /// Used during rendering to assign this carousel slide to a particular parent,
     /// so our open paging behavior works correctly.
     func assigned(at index: Int, in context: PublishingContext) -> String {
-        GroupBox {
+        Container {
             if let slideBackground = background {
                 Image(slideBackground, description: "")
                     .class("d-block", "w-100")
                     .style("height: 100%", "object-fit: cover", "opacity: \(backgroundOpacity)")
             }
 
-            GroupBox {
-                GroupBox {
+            Container {
+                Container {
                     render(context: context)
                 }
                 .class("carousel-caption")

--- a/Sources/Ignite/Elements/Slide.swift
+++ b/Sources/Ignite/Elements/Slide.swift
@@ -65,15 +65,15 @@ public struct Slide: BlockHTML {
     /// Used during rendering to assign this carousel slide to a particular parent,
     /// so our open paging behavior works correctly.
     func assigned(at index: Int, in context: PublishingContext) -> String {
-        Group {
+        GroupBox {
             if let slideBackground = background {
                 Image(slideBackground, description: "")
                     .class("d-block", "w-100")
                     .style("height: 100%", "object-fit: cover", "opacity: \(backgroundOpacity)")
             }
 
-            Group {
-                Group {
+            GroupBox {
+                GroupBox {
                     render(context: context)
                 }
                 .class("carousel-caption")

--- a/Sources/Ignite/Elements/Spacer.swift
+++ b/Sources/Ignite/Elements/Spacer.swift
@@ -42,11 +42,11 @@ public struct Spacer: BlockHTML {
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
         if case let .semantic(spacingAmount) = spacingAmount {
-            GroupBox {}
+            Container {}
                 .margin(.top, spacingAmount)
                 .render(context: context)
         } else if case let .exact(int) = spacingAmount {
-            GroupBox {}
+            Container {}
                 .frame(height: .px(int))
                 .render(context: context)
         } else {

--- a/Sources/Ignite/Elements/Spacer.swift
+++ b/Sources/Ignite/Elements/Spacer.swift
@@ -36,11 +36,11 @@ public struct Spacer: BlockHTML {
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
         if case let .semantic(spacingAmount) = spacingAmount {
-            Group {}
+            GroupBox {}
                 .margin(.top, spacingAmount)
                 .render(context: context)
         } else if case let .exact(int) = spacingAmount {
-            Group {}
+            GroupBox {}
                 .frame(height: .px(int))
                 .render(context: context)
         } else {

--- a/Sources/Ignite/Framework/Form.swift
+++ b/Sources/Ignite/Framework/Form.swift
@@ -154,7 +154,7 @@ public struct Form: BlockHTML {
             attributes.customAttributes.insert(.init(name: "target", value: "_blank"))
         }
 
-        let wrappedContent = GroupBox {
+        let wrappedContent = Container {
             ForEach(items) { item in
                 if let textField = item as? TextField {
                     renderFormField(textField)
@@ -166,7 +166,7 @@ public struct Form: BlockHTML {
             }
 
             if let honeypotName = action.service.honeypotFieldName {
-                GroupBox {
+                Container {
                     TextField(placeholder: nil)
                         .type(.text)
                         .customAttribute(name: "name", value: honeypotName)
@@ -194,7 +194,7 @@ public struct Form: BlockHTML {
         return formOutput
     }
 
-    private func renderFormField(_ textField: TextField) -> GroupBox {
+    private func renderFormField(_ textField: TextField) -> Container {
         guard let action = action(attributes.id) as? SubscribeAction else {
             fatalError("Forms support only SubscribeAction at the moment.")
         }
@@ -218,7 +218,7 @@ public struct Form: BlockHTML {
             renderSimpleItem(sizedTextField)
 
         case .floating:
-            GroupBox {
+            Container {
                 sizedTextField
                 label
             }
@@ -226,15 +226,15 @@ public struct Form: BlockHTML {
             .containerClass(getColumnClass(for: textField, totalColumns: columnCount))
 
         case .front:
-            GroupBox {
+            Container {
                 label.class("col-form-label col-sm-2")
-                GroupBox(sizedTextField).class("col-sm-10")
+                Container(sizedTextField).class("col-sm-10")
             }
             .class("row")
             .containerClass(getColumnClass(for: textField, totalColumns: columnCount))
 
         case .top:
-            GroupBox {
+            Container {
                 label.class("form-label")
                 sizedTextField
             }
@@ -242,14 +242,14 @@ public struct Form: BlockHTML {
         }
     }
 
-    private func renderButton(_ button: Button) -> GroupBox {
-        GroupBox(button.class(controlSize.buttonClass))
+    private func renderButton(_ button: Button) -> Container {
+        Container(button.class(controlSize.buttonClass))
             .class(getColumnClass(for: button, totalColumns: columnCount))
             .class("d-flex", "align-items-stretch")
     }
 
-    private func renderSimpleItem(_ item: any InlineHTML) -> GroupBox {
-        GroupBox(item)
+    private func renderSimpleItem(_ item: any InlineHTML) -> Container {
+        Container(item)
             .class(getColumnClass(for: item, totalColumns: columnCount))
     }
 

--- a/Sources/Ignite/Framework/Form.swift
+++ b/Sources/Ignite/Framework/Form.swift
@@ -154,7 +154,7 @@ public struct Form: BlockHTML {
             attributes.customAttributes.insert(.init(name: "target", value: "_blank"))
         }
 
-        let wrappedContent = Group {
+        let wrappedContent = GroupBox {
             ForEach(items) { item in
                 if let textField = item as? TextField {
                     renderFormField(textField)
@@ -166,7 +166,7 @@ public struct Form: BlockHTML {
             }
 
             if let honeypotName = action.service.honeypotFieldName {
-                Group {
+                GroupBox {
                     TextField(placeholder: nil)
                         .type(.text)
                         .customAttribute(name: "name", value: honeypotName)
@@ -194,7 +194,7 @@ public struct Form: BlockHTML {
         return formOutput
     }
 
-    private func renderFormField(_ textField: TextField) -> Group {
+    private func renderFormField(_ textField: TextField) -> GroupBox {
         guard let action = action(attributes.id) as? SubscribeAction else {
             fatalError("Forms support only SubscribeAction at the moment.")
         }
@@ -218,7 +218,7 @@ public struct Form: BlockHTML {
             renderSimpleItem(sizedTextField)
 
         case .floating:
-            Group {
+            GroupBox {
                 sizedTextField
                 label
             }
@@ -226,15 +226,15 @@ public struct Form: BlockHTML {
             .containerClass(getColumnClass(for: textField, totalColumns: columnCount))
 
         case .front:
-            Group {
+            GroupBox {
                 label.class("col-form-label col-sm-2")
-                Group(sizedTextField).class("col-sm-10")
+                GroupBox(sizedTextField).class("col-sm-10")
             }
             .class("row")
             .containerClass(getColumnClass(for: textField, totalColumns: columnCount))
 
         case .top:
-            Group {
+            GroupBox {
                 label.class("form-label")
                 sizedTextField
             }
@@ -242,14 +242,14 @@ public struct Form: BlockHTML {
         }
     }
 
-    private func renderButton(_ button: Button) -> Group {
-        Group(button.class(controlSize.buttonClass))
+    private func renderButton(_ button: Button) -> GroupBox {
+        GroupBox(button.class(controlSize.buttonClass))
             .class(getColumnClass(for: button, totalColumns: columnCount))
             .class("d-flex", "align-items-stretch")
     }
 
-    private func renderSimpleItem(_ item: any InlineHTML) -> Group {
-        Group(item)
+    private func renderSimpleItem(_ item: any InlineHTML) -> GroupBox {
+        GroupBox(item)
             .class(getColumnClass(for: item, totalColumns: columnCount))
     }
 

--- a/Sources/Ignite/Modifiers/AspectRatio.swift
+++ b/Sources/Ignite/Modifiers/AspectRatio.swift
@@ -50,12 +50,12 @@ struct AspectRatioModifier: HTMLModifier {
     func body(content: some HTML) -> any HTML {
         if let contentMode {
             if let ratio {
-                Group {
+                GroupBox {
                     content.class(contentMode.htmlClass)
                 }
                 .aspectRatio(ratio)
             } else if let customRatio {
-                Group {
+                GroupBox {
                     content.class(contentMode.htmlClass)
                 }
                 .aspectRatio(customRatio)
@@ -112,7 +112,7 @@ public extension Image {
     ///   - contentMode: The content mode to apply.
     /// - Returns: A new instance of this element with the ratio and content mode applied.
     func aspectRatio(_ ratio: AspectRatio, contentMode: ContentMode) -> some BlockHTML {
-        Group {
+        GroupBox {
             self.class(contentMode.htmlClass)
         }
         .aspectRatio(ratio)
@@ -124,7 +124,7 @@ public extension Image {
     ///   - contentMode: The content mode to apply.
     /// - Returns: A new instance of this element with the ratio and content mode applied.
     func aspectRatio(_ ratio: Double, contentMode: ContentMode) -> some BlockHTML {
-        Group {
+        GroupBox {
             self.class(contentMode.htmlClass)
         }
         .aspectRatio(ratio)

--- a/Sources/Ignite/Modifiers/AspectRatio.swift
+++ b/Sources/Ignite/Modifiers/AspectRatio.swift
@@ -50,12 +50,12 @@ struct AspectRatioModifier: HTMLModifier {
     func body(content: some HTML) -> any HTML {
         if let contentMode {
             if let ratio {
-                GroupBox {
+                Container {
                     content.class(contentMode.htmlClass)
                 }
                 .aspectRatio(ratio)
             } else if let customRatio {
-                GroupBox {
+                Container {
                     content.class(contentMode.htmlClass)
                 }
                 .aspectRatio(customRatio)
@@ -112,7 +112,7 @@ public extension Image {
     ///   - contentMode: The content mode to apply.
     /// - Returns: A new instance of this element with the ratio and content mode applied.
     func aspectRatio(_ ratio: AspectRatio, contentMode: ContentMode) -> some BlockHTML {
-        GroupBox {
+        Container {
             self.class(contentMode.htmlClass)
         }
         .aspectRatio(ratio)
@@ -124,7 +124,7 @@ public extension Image {
     ///   - contentMode: The content mode to apply.
     /// - Returns: A new instance of this element with the ratio and content mode applied.
     func aspectRatio(_ ratio: Double, contentMode: ContentMode) -> some BlockHTML {
-        GroupBox {
+        Container {
             self.class(contentMode.htmlClass)
         }
         .aspectRatio(ratio)

--- a/Sources/Ignite/Publishing/PublishingContext-Generators.swift
+++ b/Sources/Ignite/Publishing/PublishingContext-Generators.swift
@@ -67,7 +67,7 @@ extension PublishingContext {
 
             let body = TagContext.withCurrentTag(tag, content: content(tagged: tag)) {
                 let tagLayoutBody = site.tagLayout.body
-                return Group(tagLayoutBody)
+                return GroupBox(tagLayoutBody)
             }
 
             let page = Page(

--- a/Sources/Ignite/Publishing/PublishingContext-Generators.swift
+++ b/Sources/Ignite/Publishing/PublishingContext-Generators.swift
@@ -71,7 +71,7 @@ extension PublishingContext {
 
             let body = TagContext.withCurrentTag(tag, content: content(tagged: tag)) {
                 let tagLayoutBody = site.tagLayout.body
-                return GroupBox(tagLayoutBody)
+                return Container(tagLayoutBody)
             }
 
             let page = Page(

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -292,7 +292,7 @@ public final class PublishingContext {
         let layout = try layout(for: content)
 
         let body = ContentContext.withCurrentContent(content) {
-            GroupBox(context: self, items: [layout.body])
+            Container(context: self, items: [layout.body])
         }
 
         currentRenderingPath = content.path

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -292,7 +292,7 @@ public final class PublishingContext {
         let layout = try layout(for: content)
 
         let body = ContentContext.withCurrentContent(content) {
-            Group(context: self, items: [layout.body])
+            GroupBox(context: self, items: [layout.body])
         }
 
         currentRenderingPath = content.path


### PR DESCRIPTION
Like SwiftUI, `Group` is now a type that simply passes attributes to its children—how `Group(isTransparent:)` worked. `GroupBox` is a structural type that wraps its children in a `div`—how `Group()` worked.