### PR TITLE
Redo: Add `ResponsiveValue` enum and implement responsive overloads for `horizontalAlignment()` and `font()` modifiers.

### DIFF
--- a/Sources/Ignite/Modifiers/HorizontalAlignment.swift
+++ b/Sources/Ignite/Modifiers/HorizontalAlignment.swift
@@ -6,7 +6,7 @@
 //
 
 /// Controls how elements are horizontally positioned inside their container.
-public enum HorizontalAlignment: String, Equatable, Sendable {
+public enum HorizontalAlignment: String, Sendable, Equatable {
     /// Elements are positioned at the start of their container.
     case leading = "text-start"
 
@@ -24,9 +24,7 @@ public enum HorizontalAlignment: String, Equatable, Sendable {
         case .trailing: "justify-content-end"
         }
     }
-}
 
-extension HorizontalAlignment {
     /// Converts HorizontalAlignment to CSS justify-content values
     var justifyContent: String {
         switch self {
@@ -37,27 +35,55 @@ extension HorizontalAlignment {
     }
 }
 
+extension HorizontalAlignment: Responsive {
+    public func responsiveClass(for breakpoint: String?) -> String {
+        let alignmentClass = rawValue.dropFirst(5) // Remove "text-" prefix
+        if let breakpoint {
+            return "text-\(breakpoint)-\(alignmentClass)"
+        }
+        return "text-\(alignmentClass)"
+    }
+}
+
 /// Determines which elements can have horizontal alignment attached,
 public protocol HorizontalAligning: HTML { }
 
 /// A modifier that controls horizontal alignment of HTML elements
 struct HorizontalAlignmentModifier: HTMLModifier {
     /// The alignment to apply
-    var alignment: HorizontalAlignment
+    let alignments: [ResponsiveAlignment]
+
+    init(alignment: HorizontalAlignment) {
+        self.alignments = [.small(alignment)]
+    }
+
+    init(alignments: [ResponsiveAlignment]) {
+        self.alignments = alignments
+    }
 
     /// Applies horizontal alignment to the provided HTML content
     /// - Parameter content: The HTML element to modify
     /// - Returns: The modified HTML with alignment applied
     func body(content: some HTML) -> any HTML {
-        content.class(alignment.rawValue)
+        let classes = alignments
+            .map(\.breakpointClass)
+            .joined(separator: " ")
+        return content.class(classes)
     }
 }
 
 public extension HorizontalAligning {
-    /// Aligns this element using the specific alignment.
+    /// Aligns this element using a specific alignment.
     /// - Parameter alignment: How to align this element.
     /// - Returns: A modified copy of the element with alignment applied
     func horizontalAlignment(_ alignment: HorizontalAlignment) -> some HTML {
         modifier(HorizontalAlignmentModifier(alignment: alignment))
+    }
+
+    /// Aligns this element using multiple responsive alignments.
+    /// - Parameter alignments: One or more alignments with optional breakpoints.
+    /// - Returns: A modified copy of the element with alignments applied
+    func horizontalAlignment(_ alignments: ResponsiveAlignment...) -> some HTML {
+        modifier(HorizontalAlignmentModifier(alignments: alignments))
     }
 }

--- a/Sources/Ignite/Styles/ResponsiveValue.swift
+++ b/Sources/Ignite/Styles/ResponsiveValue.swift
@@ -1,0 +1,67 @@
+//
+// ResponsiveValue.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+/// Protocol for types that can be represented as Bootstrap classes
+public protocol Responsive {
+    /// Returns the Bootstrap class representation of this value
+    /// - Parameter breakpoint: Optional breakpoint identifier (e.g., "md", "lg")
+    /// - Returns: A Bootstrap class name for this value at the given breakpoint
+    func responsiveClass(for breakpoint: String?) -> String
+}
+
+/// Defines how a value changes across different screen sizes.
+///
+/// Use `ResponsiveValue` to specify responsive behavior at different breakpoints:
+/// ```swift
+/// Text("Hello")
+///     // Font size changes at different breakpoints
+///     .font(.system(size: .small(12), .medium(14), .large(16)))
+///
+///     // Padding adjusts responsively
+///     .padding(.small(8), .medium(16), .large(24))
+/// ```
+public enum ResponsiveValue<Value>: Hashable, Equatable, Sendable where Value: Equatable & Hashable & Sendable {
+    /// Applies value at the small breakpoint (≤576px)
+    case small(Value)
+
+    /// Applies value at the medium breakpoint (≥768px)
+    case medium(Value)
+
+    /// Applies value at the large breakpoint (≥992px)
+    case large(Value)
+
+    /// Applies value at the extra large breakpoint (≥1200px)
+    case extraLarge(Value)
+
+    /// Applies value at the extra extra large breakpoint (≥1400px)
+    case extraExtraLarge(Value)
+
+    /// Returns the breakpoint and value for this responsive value
+    var resolved: (breakpoint: String?, value: Value) {
+        switch self {
+        case .small(let value): (nil, value)
+        case .medium(let value): ("md", value)
+        case .large(let value): ("lg", value)
+        case .extraLarge(let value): ("xl", value)
+        case .extraExtraLarge(let value): ("xxl", value)
+        }
+    }
+}
+
+extension ResponsiveValue where Value: Responsive {
+    /// The corresponding Bootstrap class for this responsive value
+    var breakpointClass: String {
+        let (breakpoint, value) = resolved
+        return value.responsiveClass(for: breakpoint)
+    }
+}
+
+/// Defines horizontal alignment behavior across different screen sizes
+public typealias ResponsiveAlignment = ResponsiveValue<HorizontalAlignment>
+
+/// Defines font size behavior across different screen sizes
+public typealias ResponsiveFontSize = ResponsiveValue<LengthUnit>

--- a/Sources/Ignite/Themes/Fonts/Font.swift
+++ b/Sources/Ignite/Themes/Fonts/Font.swift
@@ -16,8 +16,11 @@ public struct Font: Hashable, Equatable, Sendable {
     /// The semantic level of the font, such as title or body text.
     let style: Font.Style?
 
-    /// The size of the font in pixels, if specified.
-    let size: Double?
+    /// The size of the font, if specified.
+    let size: LengthUnit?
+
+    /// The responsive sizes for this font
+    let responsiveSizes: [ResponsiveFontSize]
 
     /// The weight (boldness) of the font.
     let weight: Font.Weight
@@ -78,7 +81,7 @@ public struct Font: Hashable, Equatable, Sendable {
     public init(
         name: String,
         style: Font.Style? = nil,
-        size: Double? = nil,
+        size: LengthUnit? = nil,
         weight: Font.Weight = .regular,
         sources: [FontSource] = []
     ) {
@@ -87,6 +90,7 @@ public struct Font: Hashable, Equatable, Sendable {
         self.style = style
         self.size = size
         self.weight = weight
+        self.responsiveSizes = []
     }
 
     /// Creates a font with the specified name and font sources.
@@ -107,11 +111,39 @@ public struct Font: Hashable, Equatable, Sendable {
         self.init(name: name, style: style, sources: [FontSource(url: URL(string: source)!)])
     }
 
+    init(name: String, style: Style? = nil, sizes: [ResponsiveFontSize] = [], weight: Weight = .regular) {
+        self.name = name
+        self.style = style
+        self.responsiveSizes = sizes
+        self.weight = weight
+        self.size = nil
+        self.sources = []
+    }
+
     /// Creates a system font with the specified style
     /// - Parameter style: The font style to use
+    /// - Parameter size: The font size to use
+    /// - Parameter weight: The font weight to use
     /// - Returns: A Font instance configured with the system font
-    public static func system(_ style: Font.Style? = nil, size: Double? = nil, weight: Font.Weight = .regular) -> Font {
+    public static func system(
+        _ style: Font.Style? = nil,
+        size: LengthUnit? = nil,
+        weight: Font.Weight = .regular
+    ) -> Font {
         Font(name: "", style: style, size: size, weight: weight)
+    }
+
+    /// Creates a system font with responsive sizing
+    /// - Parameter style: The font style to use
+    /// - Parameter sizes: One or more sizes that change at different breakpoints
+    /// - Parameter weight: The font weight to use
+    /// - Returns: A Font instance configured with responsive sizing
+    public static func system(
+        _ style: Font.Style? = nil,
+        size sizes: ResponsiveFontSize...,
+        weight: Font.Weight = .regular
+    ) -> Font {
+        Font(name: "", style: style, sizes: sizes, weight: weight)
     }
 
     /// Creates a custom font with the specified name and size
@@ -120,7 +152,12 @@ public struct Font: Hashable, Equatable, Sendable {
     ///   - size: The size of the font in pixels
     ///   - weight: The weight (boldness) of the font
     /// - Returns: A Font instance configured with the custom font
-    public static func custom(_ name: String, style: Font.Style? = nil, size: Double? = nil, weight: Font.Weight = .regular) -> Font {
+    public static func custom(
+        _ name: String,
+        style: Font.Style? = nil,
+        size: LengthUnit? = nil,
+        weight: Font.Weight = .regular
+    ) -> Font {
         Font(name: name, style: style, size: size, weight: weight)
     }
 }


### PR DESCRIPTION
For some reason, these changes from #201 were overwritten at some point.