### PR TITLE
Rename `Container` to `Stack`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ struct CustomContentLayout: ContentLayout {
         }
 
         if content.hasTags {
-            GroupBox {
+            Stack {
                 Text("Tagged with: \(content.tags.joined(separator: ", "))")
 
                 Text("\(content.estimatedWordCount) words; \(content.estimatedReadingMinutes) minutes to read.")

--- a/Sources/Ignite/Elements/Accordion.swift
+++ b/Sources/Ignite/Elements/Accordion.swift
@@ -63,7 +63,7 @@ public struct Accordion: BlockHTML {
         // items so they can adapt accordinly.
         let accordionID = "accordion\(UUID().uuidString.truncatedHash)"
         let assignedItems = items.map { $0.assigned(to: accordionID, openMode: openMode) }
-        let output = Container { assignedItems }
+        let output = Stack { assignedItems }
             .attributes(attributes)
             .class("accordion")
             .id(accordionID)

--- a/Sources/Ignite/Elements/ButtonGroup.swift
+++ b/Sources/Ignite/Elements/ButtonGroup.swift
@@ -44,7 +44,7 @@ public struct ButtonGroup: BlockHTML {
     /// - Parameter context: The current publishing context.
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
-        Container {
+        Stack {
             content.map { $0.render(context: context) }.joined()
         }
         .class("btn-group")

--- a/Sources/Ignite/Elements/Card.swift
+++ b/Sources/Ignite/Elements/Card.swift
@@ -207,7 +207,7 @@ public struct Card: BlockHTML {
     }
 
     public func render(context: PublishingContext) -> String {
-        Container {
+        Stack {
             if let image, contentPosition.addImageFirst {
                 if imageOpacity != 1 {
                     image
@@ -246,8 +246,8 @@ public struct Card: BlockHTML {
         .render(context: context)
     }
 
-    private func renderHeader() -> Container {
-        Container {
+    private func renderHeader() -> Stack {
+        Stack {
             for item in header {
                 item
             }
@@ -255,8 +255,8 @@ public struct Card: BlockHTML {
         .class("card-header")
     }
 
-    private func renderItems() -> Container {
-        Container {
+    private func renderItems() -> Stack {
+        Stack {
             ForEach(items) { item in
                 switch item {
                 case let text as Text where text.font == .body || text.font == .lead:
@@ -275,8 +275,8 @@ public struct Card: BlockHTML {
         .class(contentPosition.bodyClasses)
     }
 
-    private func renderFooter() -> Container {
-        Container {
+    private func renderFooter() -> Stack {
+        Stack {
             for item in footer {
                 item
             }

--- a/Sources/Ignite/Elements/Carousel.swift
+++ b/Sources/Ignite/Elements/Carousel.swift
@@ -58,8 +58,8 @@ public struct Carousel: BlockHTML {
     /// - Parameter context: The current publishing context.
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
-        Container {
-            Container {
+        Stack {
+            Stack {
                 ForEach(0..<items.count) { index in
                     Button()
                         .data("bs-target", "#\(carouselID)")
@@ -71,7 +71,7 @@ public struct Carousel: BlockHTML {
             }
             .class("carousel-indicators")
 
-            Container {
+            Stack {
                 ForEach(items.enumerated()) { index, item in
                     item.assigned(at: index, in: context)
                 }

--- a/Sources/Ignite/Elements/ContentPreview.swift
+++ b/Sources/Ignite/Elements/ContentPreview.swift
@@ -77,7 +77,7 @@ public struct ContentPreview: BlockHTML {
             let tagLinks = content.tagLinks()
 
             if tagLinks.isEmpty == false {
-                Container {
+                Stack {
                     tagLinks
                 }
                 .style("margin-top: -5px")

--- a/Sources/Ignite/Elements/Dropdown.swift
+++ b/Sources/Ignite/Elements/Dropdown.swift
@@ -94,7 +94,7 @@ public struct Dropdown: BlockHTML, NavigationItem {
                 .class("dropdown")
                 .render(context: context)
         } else {
-            return Container(content)
+            return Stack(content)
                 .attributes(attributes)
                 .class("dropdown")
                 .render(context: context)

--- a/Sources/Ignite/Elements/Embed.swift
+++ b/Sources/Ignite/Elements/Embed.swift
@@ -120,7 +120,7 @@ public struct Embed: BlockHTML, LazyLoadable {
             """)
         }
 
-        return Container {
+        return Stack {
              #"<iframe src="\#(url)" title="\#(title)" allow="\#(allowPermissions)"></iframe>"#
         }
         .attributes(attributes)

--- a/Sources/Ignite/Elements/Group.swift
+++ b/Sources/Ignite/Elements/Group.swift
@@ -8,14 +8,14 @@
 /// A transparent grouping construct that propagates modifiers to its children.
 ///
 /// Use `Group` when you want to apply shared modifiers to multiple elements
-/// without introducing additional HTML structure. Unlike ``Container``, `Group`
+/// without introducing additional HTML structure. Unlike ``Stack``, `Group`
 /// doesn't wrap its children in a `div`; instead, it passes modifiers through
 /// to each child element.
 ///
 /// - Note: `Group` is particularly useful for applying shared styling or
 ///         attributes to multiple elements without affecting the document
 ///         structure. If you need a containing `div` element, use
-///         ``Container`` instead.
+///         ``Stack`` instead.
 public struct Group: BlockHTML {
     /// The content and behavior of this HTML.
     public var body: some HTML { self }

--- a/Sources/Ignite/Elements/Item.swift
+++ b/Sources/Ignite/Elements/Item.swift
@@ -70,7 +70,7 @@ public struct Item: HTML {
 
         let itemID = "\(parentID)-item\(UUID().uuidString.truncatedHash)"
 
-        return Container {
+        return Stack {
             Text {
                 Button(title)
                     .class("accordion-button", startsOpen ? "" : "collapsed")
@@ -82,8 +82,8 @@ public struct Item: HTML {
             .font(.title2)
             .class("accordion-header")
 
-            Container {
-                Container {
+            Stack {
+                Stack {
                     contents.render(context: context)
                 }
                 .class("accordion-body")

--- a/Sources/Ignite/Elements/Modal.swift
+++ b/Sources/Ignite/Elements/Modal.swift
@@ -127,23 +127,23 @@ public struct Modal: HTML {
     /// - Parameter context: The current publishing context.
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
-        Container {
-            Container {
-                Container {
+        Stack {
+            Stack {
+                Stack {
                     if !header.isEmptyHTML {
-                        Container {
+                        Stack {
                             header
                         }
                         .class("modal-header")
                     }
 
-                    Container {
+                    Stack {
                         items
                     }
                     .class("modal-body")
 
                     if !footer.isEmptyHTML {
-                        Container {
+                        Stack {
                             footer
                         }
                         .class("modal-footer")

--- a/Sources/Ignite/Elements/NavigationBar.swift
+++ b/Sources/Ignite/Elements/NavigationBar.swift
@@ -159,7 +159,7 @@ public struct NavigationBar: BlockHTML {
     public func render(context: PublishingContext) -> String {
         Tag("header") {
             Tag("nav") {
-                Container {
+                Stack {
                     if let logo {
                         Link(logo, target: "/")
                             .class("navbar-brand")
@@ -189,8 +189,8 @@ public struct NavigationBar: BlockHTML {
         .aria("label", "Toggle navigation")
     }
 
-    private func renderNavItems(context: PublishingContext) -> Container {
-        Container {
+    private func renderNavItems(context: PublishingContext) -> Stack {
+        Stack {
             List {
                 ForEach(items) { item in
                     if let dropdownItem = item as? Dropdown {

--- a/Sources/Ignite/Elements/Section.swift
+++ b/Sources/Ignite/Elements/Section.swift
@@ -94,7 +94,7 @@ public struct Section: BlockHTML {
             }
         }
 
-        return Container {
+        return Stack {
             ForEach(items) { item in
                 if let group = item as? Group {
                     handleGroup(group, attributes: group.attributes)
@@ -102,7 +102,7 @@ public struct Section: BlockHTML {
                           let group = modified.content as? Group {
                     handleGroup(group, attributes: modified.attributes)
                 } else if let item = item as? any BlockHTML {
-                    Container(item)
+                    Stack(item)
                         .class(className(for: item))
                         .class(gutterClass)
                 } else {
@@ -127,7 +127,7 @@ public struct Section: BlockHTML {
         }
         return ForEach(group.items) { item in
             if let item = item as? any BlockHTML {
-                Container(item)
+                Stack(item)
                     .class(className(for: group))
                     .class(gutterClass)
                     .attributes(attributes)

--- a/Sources/Ignite/Elements/Slide.swift
+++ b/Sources/Ignite/Elements/Slide.swift
@@ -65,15 +65,15 @@ public struct Slide: BlockHTML {
     /// Used during rendering to assign this carousel slide to a particular parent,
     /// so our open paging behavior works correctly.
     func assigned(at index: Int, in context: PublishingContext) -> String {
-        Container {
+        Stack {
             if let slideBackground = background {
                 Image(slideBackground, description: "")
                     .class("d-block", "w-100")
                     .style("height: 100%", "object-fit: cover", "opacity: \(backgroundOpacity)")
             }
 
-            Container {
-                Container {
+            Stack {
+                Stack {
                     render(context: context)
                 }
                 .class("carousel-caption")

--- a/Sources/Ignite/Elements/Spacer.swift
+++ b/Sources/Ignite/Elements/Spacer.swift
@@ -42,11 +42,11 @@ public struct Spacer: BlockHTML {
     /// - Returns: The HTML for this element.
     public func render(context: PublishingContext) -> String {
         if case let .semantic(spacingAmount) = spacingAmount {
-            Container {}
+            Stack {}
                 .margin(.top, spacingAmount)
                 .render(context: context)
         } else if case let .exact(int) = spacingAmount {
-            Container {}
+            Stack {}
                 .frame(height: .px(int))
                 .render(context: context)
         } else {

--- a/Sources/Ignite/Elements/Stack.swift
+++ b/Sources/Ignite/Elements/Stack.swift
@@ -11,9 +11,9 @@
 /// within a containing HTML `div`. This is useful for applying shared styling,
 /// creating layout structures, or logically grouping related content.
 ///
-/// - Note: Unlike ``Group``, modifiers applied to a `Container` affect the
+/// - Note: Unlike ``Group``, modifiers applied to a `Stack` affect the
 ///         containing `div` element rather than being propagated to child elements.
-public struct Container: BlockHTML {
+public struct Stack: BlockHTML {
     /// The content and behavior of this HTML.
     public var body: some HTML { self }
 

--- a/Sources/Ignite/Framework/Form.swift
+++ b/Sources/Ignite/Framework/Form.swift
@@ -154,7 +154,7 @@ public struct Form: BlockHTML {
             attributes.customAttributes.insert(.init(name: "target", value: "_blank"))
         }
 
-        let wrappedContent = Container {
+        let wrappedContent = Stack {
             ForEach(items) { item in
                 if let textField = item as? TextField {
                     renderFormField(textField)
@@ -166,7 +166,7 @@ public struct Form: BlockHTML {
             }
 
             if let honeypotName = action.service.honeypotFieldName {
-                Container {
+                Stack {
                     TextField(placeholder: nil)
                         .type(.text)
                         .customAttribute(name: "name", value: honeypotName)
@@ -194,7 +194,7 @@ public struct Form: BlockHTML {
         return formOutput
     }
 
-    private func renderFormField(_ textField: TextField) -> Container {
+    private func renderFormField(_ textField: TextField) -> Stack {
         guard let action = action(attributes.id) as? SubscribeAction else {
             fatalError("Forms support only SubscribeAction at the moment.")
         }
@@ -218,7 +218,7 @@ public struct Form: BlockHTML {
             renderSimpleItem(sizedTextField)
 
         case .floating:
-            Container {
+            Stack {
                 sizedTextField
                 label
             }
@@ -226,15 +226,15 @@ public struct Form: BlockHTML {
             .containerClass(getColumnClass(for: textField, totalColumns: columnCount))
 
         case .front:
-            Container {
+            Stack {
                 label.class("col-form-label col-sm-2")
-                Container(sizedTextField).class("col-sm-10")
+                Stack(sizedTextField).class("col-sm-10")
             }
             .class("row")
             .containerClass(getColumnClass(for: textField, totalColumns: columnCount))
 
         case .top:
-            Container {
+            Stack {
                 label.class("form-label")
                 sizedTextField
             }
@@ -242,14 +242,14 @@ public struct Form: BlockHTML {
         }
     }
 
-    private func renderButton(_ button: Button) -> Container {
-        Container(button.class(controlSize.buttonClass))
+    private func renderButton(_ button: Button) -> Stack {
+        Stack(button.class(controlSize.buttonClass))
             .class(getColumnClass(for: button, totalColumns: columnCount))
             .class("d-flex", "align-items-stretch")
     }
 
-    private func renderSimpleItem(_ item: any InlineHTML) -> Container {
-        Container(item)
+    private func renderSimpleItem(_ item: any InlineHTML) -> Stack {
+        Stack(item)
             .class(getColumnClass(for: item, totalColumns: columnCount))
     }
 

--- a/Sources/Ignite/Modifiers/AspectRatio.swift
+++ b/Sources/Ignite/Modifiers/AspectRatio.swift
@@ -50,12 +50,12 @@ struct AspectRatioModifier: HTMLModifier {
     func body(content: some HTML) -> any HTML {
         if let contentMode {
             if let ratio {
-                Container {
+                Stack {
                     content.class(contentMode.htmlClass)
                 }
                 .aspectRatio(ratio)
             } else if let customRatio {
-                Container {
+                Stack {
                     content.class(contentMode.htmlClass)
                 }
                 .aspectRatio(customRatio)
@@ -112,7 +112,7 @@ public extension Image {
     ///   - contentMode: The content mode to apply.
     /// - Returns: A new instance of this element with the ratio and content mode applied.
     func aspectRatio(_ ratio: AspectRatio, contentMode: ContentMode) -> some BlockHTML {
-        Container {
+        Stack {
             self.class(contentMode.htmlClass)
         }
         .aspectRatio(ratio)
@@ -124,7 +124,7 @@ public extension Image {
     ///   - contentMode: The content mode to apply.
     /// - Returns: A new instance of this element with the ratio and content mode applied.
     func aspectRatio(_ ratio: Double, contentMode: ContentMode) -> some BlockHTML {
-        Container {
+        Stack {
             self.class(contentMode.htmlClass)
         }
         .aspectRatio(ratio)

--- a/Sources/Ignite/Publishing/PublishingContext-Generators.swift
+++ b/Sources/Ignite/Publishing/PublishingContext-Generators.swift
@@ -70,7 +70,7 @@ extension PublishingContext {
 
             let body = TagContext.withCurrentTag(tag, content: content(tagged: tag)) {
                 let tagLayoutBody = site.tagLayout.body
-                return Container(tagLayoutBody)
+                return Stack(tagLayoutBody)
             }
 
             let page = Page(

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -292,7 +292,7 @@ public final class PublishingContext {
         let layout = try layout(for: content)
 
         let body = ContentContext.withCurrentContent(content) {
-            Container(context: self, items: [layout.body])
+            Stack(context: self, items: [layout.body])
         }
 
         currentRenderingPath = content.path

--- a/Sources/Ignite/Styles/SpacingAmount.swift
+++ b/Sources/Ignite/Styles/SpacingAmount.swift
@@ -7,7 +7,7 @@
 
 /// Adaptive spacing amounts that are used by Bootstrap to provide consistency
 /// in site design.
-public enum SpacingAmount: Double {
+public enum SpacingAmount: Int {
     case none = 0
     case extraSmall
     case small


### PR DESCRIPTION
This PR renames the `Container` type to `Stack`. Here's the reasoning behind this change:

The original `Container` name had several drawbacks:
1. It could be confused with Bootstrap's `container` class, potentially leading to incorrect assumptions about its behavior—the main reason it wasn't my first choice initially.
2. The name didn't clearly communicate its purpose or functionality.
3. It introduced a standalone concept without established context in the Ignite ecosystem.

When I made my initial PR, `Container` seemed like the best option. But an unexpected moment of inspiration led me to `Stack` as a superior alternative because:
1. It builds upon our existing layout-related `Stack` types, providing better conceptual consistency.
2. It's more concise.
3. It avoids potential naming conflicts with Bootstrap conventions.

This rename improves clarity and better aligns with our existing type system.