### PR TITLE
Fix access to file paths: do not use percent encoding

### DIFF
--- a/Sources/Ignite/Framework/DecodeAction.swift
+++ b/Sources/Ignite/Framework/DecodeAction.swift
@@ -28,7 +28,7 @@ public struct DecodeAction {
     public func url(forResource resource: String) -> URL? {
         let fullURL = sourceDirectory.appending(path: "Resources/\(resource)")
 
-        if FileManager.default.fileExists(atPath: fullURL.path()) {
+        if FileManager.default.fileExists(atPath: fullURL.path(percentEncoded: false)) {
             return fullURL
         } else {
             return nil

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -165,7 +165,7 @@ public final class PublishingContext {
         try copyAssets()
         try copyFonts()
 
-        if !FileManager.default.fileExists(atPath: buildDirectory.appending(path: "css/themes.min.css").path()) {
+        if !FileManager.default.fileExists(atPath: buildDirectory.appending(path: "css/themes.min.css").path(percentEncoded: false)) {
             try copy(resource: "css/themes.min.css")
         }
 


### PR DESCRIPTION
As shown in issue #57, space characters in a path can lead to build errors, due to percent encoding being used in URL paths. By using `.path(percentEncoded: false)` the original path can be retrieved.

Below is the code from #57 adapted to the new syntax

```swift
struct Home: StaticLayout {
    @Environment(\.decode) var decode
    var title = "Home"

    var body: some HTML {
        let page = decode.data(forResource: "about.md")!
        let str = String(decoding: page, as: UTF8.self)
        
        Text(title)
            .font(.title3)
        
        Text(markdown: str)
    }
}
```