### PR TITLE
Separate build and run commands to show runtime messages

### DIFF
--- a/Sources/IgniteCLI/BuildCommand.swift
+++ b/Sources/IgniteCLI/BuildCommand.swift
@@ -25,7 +25,9 @@ struct BuildCommand: ParsableCommand {
        }
 
         print("⚙️  Building your site...")
-        let (_, error) = try Process.execute(command: "swift run")
+
+        // Build executable and report errors & earnings
+        let (_, error) = try Process.execute(command: "swift build")
 
         // If something went wrong, print a message then
         // bail out.
@@ -39,6 +41,24 @@ struct BuildCommand: ParsableCommand {
             // Warnings can just be printed; they won't hold
             // up a successful build.
             print(error)
+        }
+
+        // Execute site generation with output, and report errors & earnings
+        let (output, runError) = try Process.execute(command: "swift run")
+        print(output)
+
+        // If something went wrong, print a message then
+        // bail out.
+        if runError.contains("error:") {
+            print(runError)
+
+            print("")
+            print("❌ Failed to generate HTML.")
+            return
+        } else if runError.contains("warning:") {
+            // Warnings can just be printed; they won't hold
+            // up a successful build.
+            print(runError)
         }
 
         print("✅ Successfully built!")


### PR DESCRIPTION
By separating the two phases we can show the runtime errors/warnings to the user.

Doing this finally shows the warnings of "IgniteSamples" also in the console:

```
Publish completed with warnings:
	- /images/photos/dishwasher.jpg: adding images without a description is not recommended. Provide a description or use Image(decorative:) to silence this warning.
```

Further it might have avoided issue https://github.com/twostraws/Ignite/issues/64 as the runtime warning "Your site must provide at least one layout in order to render Markdown." would have been shown to the user.
