### PR TITLE
Fix compiler warnings.

### DIFF
--- a/Sources/Ignite/Elements/Text.swift
+++ b/Sources/Ignite/Elements/Text.swift
@@ -124,7 +124,7 @@ public struct Text: BlockHTML, DropdownElement {
 }
 
 extension HTML {
-    func fontStyle(_ font: Font.Style) -> Self {
+    @discardableResult func fontStyle(_ font: Font.Style) -> Self {
         if font == .lead {
             self.class(font.rawValue)
         } else {

--- a/Sources/Ignite/Framework/ElementTypes/HTML.swift
+++ b/Sources/Ignite/Framework/ElementTypes/HTML.swift
@@ -146,7 +146,7 @@ public extension HTML {
     ///   - name: The name of the data attribute
     ///   - value: The value of the data attribute
     /// - Returns: The modified `HTML` element
-    func data(_ name: String, _ value: String?) -> Self {
+    @discardableResult func data(_ name: String, _ value: String?) -> Self {
         guard let value else { return self }
         var attributes = attributes
         attributes.data.append(AttributeValue(name: name, value: value))

--- a/Sources/Ignite/Modifiers/Border.swift
+++ b/Sources/Ignite/Modifiers/Border.swift
@@ -26,41 +26,39 @@ struct BorderModifier: HTMLModifier {
     /// - Parameter content: The HTML content to modify
     /// - Returns: The modified HTML content with border styling applied
     func body(content: some HTML) -> any HTML {
-        var modified = content
-
         // Apply border styles based on edges
         if edges.contains(.all) {
-            modified.style("border: \(width)px \(style.rawValue) \(color)")
+            content.style("border: \(width)px \(style.rawValue) \(color)")
         } else {
             if edges.contains(.leading) {
-                modified.style("border-left: \(width)px \(style.rawValue) \(color)")
+                content.style("border-left: \(width)px \(style.rawValue) \(color)")
             }
             if edges.contains(.trailing) {
-                modified.style("border-right: \(width)px \(style.rawValue) \(color)")
+                content.style("border-right: \(width)px \(style.rawValue) \(color)")
             }
             if edges.contains(.top) {
-                modified.style("border-top: \(width)px \(style.rawValue) \(color)")
+                content.style("border-top: \(width)px \(style.rawValue) \(color)")
             }
             if edges.contains(.bottom) {
-                modified.style("border-bottom: \(width)px \(style.rawValue) \(color)")
+                content.style("border-bottom: \(width)px \(style.rawValue) \(color)")
             }
         }
 
         // Apply corner radii
         if cornerRadii.topLeading > 0 {
-            modified.style("border-top-left-radius: \(cornerRadii.topLeading)px")
+            content.style("border-top-left-radius: \(cornerRadii.topLeading)px")
         }
         if cornerRadii.topTrailing > 0 {
-            modified.style("border-top-right-radius: \(cornerRadii.topTrailing)px")
+            content.style("border-top-right-radius: \(cornerRadii.topTrailing)px")
         }
         if cornerRadii.bottomLeading > 0 {
-            modified.style("border-bottom-left-radius: \(cornerRadii.bottomLeading)px")
+            content.style("border-bottom-left-radius: \(cornerRadii.bottomLeading)px")
         }
         if cornerRadii.bottomTrailing > 0 {
-            modified.style("border-bottom-right-radius: \(cornerRadii.bottomTrailing)px")
+            content.style("border-bottom-right-radius: \(cornerRadii.bottomTrailing)px")
         }
 
-        return modified
+        return content
     }
 }
 

--- a/Sources/Ignite/Modifiers/CornerRadius.swift
+++ b/Sources/Ignite/Modifiers/CornerRadius.swift
@@ -39,25 +39,23 @@ struct CornerRadiusModifier: HTMLModifier {
             return content.style("border-radius: \(length)")
         }
 
-        var modified = content
-
         if edges.contains(.topLeading) {
-            modified.style("border-top-left-radius: \(length)")
+            content.style("border-top-left-radius: \(length)")
         }
 
         if edges.contains(.topTrailing) {
-            modified.style("border-top-right-radius: \(length)")
+            content.style("border-top-right-radius: \(length)")
         }
 
         if edges.contains(.bottomLeading) {
-            modified.style("border-bottom-left-radius: \(length)")
+            content.style("border-bottom-left-radius: \(length)")
         }
 
         if edges.contains(.bottomTrailing) {
-            modified.style("border-bottom-right-radius: \(length)")
+            content.style("border-bottom-right-radius: \(length)")
         }
 
-        return modified
+        return content
     }
 }
 

--- a/Sources/Ignite/Modifiers/FontModifier.swift
+++ b/Sources/Ignite/Modifiers/FontModifier.swift
@@ -67,24 +67,24 @@ struct FontModifier: HTMLModifier {
             (content as? ModifiedHTML)?.content is Text
 
         if isText {
-            var modified = content.style("font-weight: \(font.weight.rawValue)")
+            content.style("font-weight: \(font.weight.rawValue)")
 
             if let style = font.style {
-                modified.fontStyle(style)
+                content.fontStyle(style)
             }
 
             if let name = font.name, name.isEmpty == false {
-                modified.style("font-family: \(name)")
+                content.style("font-family: \(name)")
             }
 
             if !font.responsiveSizes.isEmpty {
                 let classNames = registerResponsiveClasses()
-                modified.class(classNames)
+                content.class(classNames)
             } else if let size = font.size {
-                modified.style("font-size: \(size.stringValue)")
+                content.style("font-size: \(size.stringValue)")
             }
 
-            return modified
+            return content
         } else {
             var containerAttributes = ContainerAttributes(styles: [
                 .init(name: "font-weight", value: String(font.weight.rawValue))

--- a/Sources/Ignite/Modifiers/Hint.swift
+++ b/Sources/Ignite/Modifiers/Hint.swift
@@ -40,14 +40,15 @@ struct HintModifier: HTMLModifier {
     /// - Parameter content: The HTML element to modify
     /// - Returns: The modified HTML with tooltip applied
     func body(content: some HTML) -> any HTML {
-        var modified = content.data("bs-toggle", "tooltip")
+        content
+            .data("bs-toggle", "tooltip")
             .data("bs-title", text)
 
         if isHTML {
-            modified.data("bs-html", "true")
+            content.data("bs-html", "true")
         }
 
-        return modified
+        return content
     }
 }
 


### PR DESCRIPTION
The only way to avoid the new`@discardableResult` for `fontStyle()` would be to use the pattern:

```swift
var modified = content
modified = modified.fontStyle()
// etc.
```

Let me know if that is preferable.