### PR TITLE
Rename `PlainText.swift` to `String.swift`, to better match the underlying element

### DIFF
--- a/Sources/Ignite/Elements/String.swift
+++ b/Sources/Ignite/Elements/String.swift
@@ -1,5 +1,5 @@
 //
-// PlainText.swift
+// String.swift
 // Ignite
 // https://www.github.com/twostraws/Ignite
 // See LICENSE for license information.

--- a/Sources/Ignite/Framework/ElementTypes/InlineHTML.swift
+++ b/Sources/Ignite/Framework/ElementTypes/InlineHTML.swift
@@ -1,5 +1,5 @@
 //
-// InlineElement.swift
+// InlineHTML.swift
 // Ignite
 // https://www.github.com/twostraws/Ignite
 // See LICENSE for license information.

--- a/Tests/IgniteTesting/Elements/String.swift
+++ b/Tests/IgniteTesting/Elements/String.swift
@@ -1,5 +1,5 @@
 //
-// PlainText.swift
+// String.swift
 // Ignite
 // https://www.github.com/twostraws/Ignite
 // See LICENSE for license information.
@@ -10,16 +10,16 @@ import Testing
 
 @testable import Ignite
 
-/// Tests for plain text.
-@Suite("Plain Text Tests")
-@MainActor struct PlainTextTests {
+/// Tests for Strings (aka Plain Text)
+@Suite("String Tests")
+@MainActor struct StringTests {
     let publishingContext = ElementTest.publishingContext
 
-    @Test("Single Element", arguments: ["This is a test"])
+    @Test("Single Element", arguments: ["This is a test", ""])
     func test_singleElement(element: String) async throws {
         let element = element
         let output = element.render(context: publishingContext)
 
-        #expect(output == "This is a test")
+        #expect(output == element)
     }
 }


### PR DESCRIPTION
Also adjusts some tests to contain an empty String (`""`) case.

Very minor updates, noticed while poking around the project.