### PR TITLE
Fixing dumb variable name in Opacity test

### DIFF
--- a/Tests/IgniteTesting/Modifiers/Opacity.swift
+++ b/Tests/IgniteTesting/Modifiers/Opacity.swift
@@ -16,11 +16,11 @@ import Testing
 struct OpacityTests {
 
     @Test("Text Opacity Test", arguments: ["This is a test", "Another test"])
-    func textOpacity(textText: String) async throws {
-        let element = Text(textText).opacity(0.5)
+    func textOpacity(text: String) async throws {
+        let element = Text(text).opacity(0.5)
         let output = element.render()
 
-        #expect(output == "<p style=\"opacity: 0.5\">\(textText)</p>")
+        #expect(output == "<p style=\"opacity: 0.5\">\(text)</p>")
     }
 
     @Test("Image Opacity Test", arguments: [(path: "/images/example.jpg", description: "Example image")])


### PR DESCRIPTION
No more textText