### PR TITLE
Test for Font Style

### DIFF
--- a/Tests/IgniteTesting/Modifiers/FontStyleModifier.swift
+++ b/Tests/IgniteTesting/Modifiers/FontStyleModifier.swift
@@ -14,8 +14,17 @@ import Testing
 @Suite("FontStyleModifier Tests")
 @MainActor
 struct FontStyleModifierTests {
-    @Test("ExampleTest")
-    func example() async throws {
+    @Test("Font Style Test")
+    func fontStyleExcludingLead() async throws {
+        for font in Font.Style.allCases {
+            if font != .lead {
+                let element = Text("Hello").font(font)
 
+                let output = element.render()
+
+                #expect(
+                    output == "<\(font.description)>Hello</\(font.description)>")
+            }
+        }
     }
 }


### PR DESCRIPTION
Looking at the `enum Style` for Font there is a lead for larger variant of body text using Bootstrap's large font size (1.25rem), so I excluded this one.