### PR TITLE
Add tests for rfc822

### DIFF
--- a/Sources/Ignite/Extensions/Date-RFC822.swift
+++ b/Sources/Ignite/Extensions/Date-RFC822.swift
@@ -12,6 +12,7 @@ extension Date {
     public var asRFC822: String {
         let formatter = DateFormatter()
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
         return formatter.string(from: self)
     }
 }

--- a/Tests/IgniteTesting/Extensions/Date-RFC822.swift
+++ b/Tests/IgniteTesting/Extensions/Date-RFC822.swift
@@ -36,9 +36,3 @@ struct DateRFC822Tests {
         #expect(instance.input.asRFC822 == instance.expected)
     }
 }
-
-extension Date {
-    static func random() -> Date {
-        Date(timeIntervalSince1970: .random(in: Date.distantPast.timeIntervalSince1970 ... Date.distantFuture.timeIntervalSince1970))
-    }
-}

--- a/Tests/IgniteTesting/Extensions/Date-RFC822.swift
+++ b/Tests/IgniteTesting/Extensions/Date-RFC822.swift
@@ -19,22 +19,7 @@ struct DateRFC822Tests {
         let input: Date
         let expected: String
     }
-    
-    // use this to output a list of strings to the console that we can use as input in a test
-    @Test
-    func convertToInstance() {
         
-        let formatter = DateFormatter()
-        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-
-        let dates = (0 ..< 10).map { _ in Date.random() }
-        for date in dates {
-            let time = date.timeIntervalSince1970
-            print("Instance(input: Date(timeIntervalSince1970: \(time)), expected: \"\(date.asRFC822)\"),")
-        }
-    }
-    
     @Test("Test Against Known Output", arguments: [
         Instance(input: Date(timeIntervalSince1970: 60228332501.13208), expected: "Wed, 24 Jul 3878 04:21:41 +0000"),
         Instance(input: Date(timeIntervalSince1970: 27871740518.22975), expected: "Fri, 21 Mar 2853 14:08:38 +0000"),
@@ -45,7 +30,7 @@ struct DateRFC822Tests {
         Instance(input: Date(timeIntervalSince1970: 9676773717.779556), expected: "Wed, 23 Aug 2276 16:41:57 +0000"),
         Instance(input: Date(timeIntervalSince1970: -46716978084.27513), expected: "Sat, 05 Aug 0489 05:38:35 +0000"),
         Instance(input: Date(timeIntervalSince1970: 60228133082.71135), expected: "Sun, 21 Jul 3878 20:58:02 +0000"),
-        Instance(input: Date(timeIntervalSince1970: -37373736994.632614), expected: "Tue, 30 Aug 0785 14:23:25 +0000"),
+        Instance(input: Date(timeIntervalSince1970: -37373736994.632614), expected: "Tue, 30 Aug 0785 14:23:25 +0000")
     ])
     func outputs_expected_result(instance: Instance) async throws {
         #expect(instance.input.asRFC822 == instance.expected)

--- a/Tests/IgniteTesting/Extensions/Date-RFC822.swift
+++ b/Tests/IgniteTesting/Extensions/Date-RFC822.swift
@@ -14,8 +14,46 @@ import Testing
 @Suite("Date-RFC822 Tests")
 @MainActor
 struct DateRFC822Tests {
-    @Test("ExampleTest")
-    func example() async throws {
+    
+    struct Instance {
+        let input: Date
+        let expected: String
+    }
+    
+    // use this to output a list of strings to the console that we can use as input in a test
+    @Test
+    func convertToInstance() {
+        
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
 
+        let dates = (0 ..< 10).map { _ in Date.random() }
+        for date in dates {
+            let time = date.timeIntervalSince1970
+            print("Instance(input: Date(timeIntervalSince1970: \(time)), expected: \"\(date.asRFC822)\"),")
+        }
+    }
+    
+    @Test("Test Against Known Output", arguments: [
+        Instance(input: Date(timeIntervalSince1970: 60228332501.13208), expected: "Wed, 24 Jul 3878 04:21:41 +0000"),
+        Instance(input: Date(timeIntervalSince1970: 27871740518.22975), expected: "Fri, 21 Mar 2853 14:08:38 +0000"),
+        Instance(input: Date(timeIntervalSince1970: -3284356034.069809), expected: "Sun, 03 Dec 1865 14:52:45 +0000"),
+        Instance(input: Date(timeIntervalSince1970: 17552683531.75113), expected: "Sat, 23 Mar 2526 01:25:31 +0000"),
+        Instance(input: Date(timeIntervalSince1970: 52184037958.68115), expected: "Thu, 24 Aug 3623 22:05:58 +0000"),
+        Instance(input: Date(timeIntervalSince1970: -46964633818.02554), expected: "Tue, 29 Sep 0481 20:23:01 +0000"),
+        Instance(input: Date(timeIntervalSince1970: 9676773717.779556), expected: "Wed, 23 Aug 2276 16:41:57 +0000"),
+        Instance(input: Date(timeIntervalSince1970: -46716978084.27513), expected: "Sat, 05 Aug 0489 05:38:35 +0000"),
+        Instance(input: Date(timeIntervalSince1970: 60228133082.71135), expected: "Sun, 21 Jul 3878 20:58:02 +0000"),
+        Instance(input: Date(timeIntervalSince1970: -37373736994.632614), expected: "Tue, 30 Aug 0785 14:23:25 +0000"),
+    ])
+    func outputs_expected_result(instance: Instance) async throws {
+        #expect(instance.input.asRFC822 == instance.expected)
+    }
+}
+
+extension Date {
+    static func random() -> Date {
+        Date(timeIntervalSince1970: .random(in: Date.distantPast.timeIntervalSince1970 ... Date.distantFuture.timeIntervalSince1970))
     }
 }

--- a/Tests/IgniteTesting/Extensions/Date-RFC822.swift
+++ b/Tests/IgniteTesting/Extensions/Date-RFC822.swift
@@ -14,12 +14,12 @@ import Testing
 @Suite("Date-RFC822 Tests")
 @MainActor
 struct DateRFC822Tests {
-    
+
     struct Instance {
         let input: Date
         let expected: String
     }
-        
+
     @Test("Test Against Known Output", arguments: [
         Instance(input: Date(timeIntervalSince1970: 60228332501.13208), expected: "Wed, 24 Jul 3878 04:21:41 +0000"),
         Instance(input: Date(timeIntervalSince1970: 27871740518.22975), expected: "Fri, 21 Mar 2853 14:08:38 +0000"),


### PR DESCRIPTION
I generated 10 random dates and expected output for each of them from Date.asRFC822.

I then encountered an issue:
RFC822 includes time zone information, but time zone of course is dependent on location.

DateFormatter.string(from:) defaults to using the timezone of the computer on which it's being run. So, as Date.asRFC822 is currently written, there is no way to create a set of tests that use an expected output string unless the computer on which the test is being run is in the same timezone as the test server. Either the tests will pass on the development machine and fail on the server, or the tests will fail on the development machine and pass on the server.

This also means that Date.asRFC822 is non-deterministic because it's location-dependent, which could be an issue in the future.

There are two possible solutions:
1) convert Date.asRFC822 to a function that takes a timezone value
2) have Date.asRFC822 use a standard timezone at all times.

I opted for the second approach and modified Date.asRFC822 to always use GMT. This means that all output will end with "+0000".

I then could use the output of the modified Date.asRFC822 to generate 10 Instance values that could be tested against consistently on any computer.
