### PR TITLE
added a test to ensure that words separated by dashes are lowercased.

### DIFF
--- a/Tests/IgniteTesting/Extensions/String-KebabCased.swift
+++ b/Tests/IgniteTesting/Extensions/String-KebabCased.swift
@@ -79,6 +79,16 @@ struct StringKebabCasedTests {
         #expect(instance.input.kebabCased() == instance.expected)
     }
 
+    @Test("Converts words-separated-by-dashes to all lowercase", arguments: [
+        Instance(input: "Hello-World", expected: "hello-world"),
+        Instance(input: "Hello-world", expected: "hello-world"),
+        Instance(input: "hello-World", expected: "hello-world"),
+        Instance(input: "HELLO-WORLD", expected: "hello-world")
+    ])
+    func converts_to_lowercase_leaving_dashes (instance: Instance) async throws {
+        #expect(instance.input.kebabCased() == instance.expected)
+    }
+
     @Test(
         "Complex Examples",
         arguments: [


### PR DESCRIPTION
This is a case that I hadn't considered explicitly before.
I added a test to cover this case