### PR TITLE
Makes invoking `swiftling` more convenient

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -14,3 +14,10 @@ identifier_name:
     - id
     - to
     - up
+
+# Case-sensitive paths to include during linting. Directory paths supplied on the
+# command line will be ignored.
+included:
+    - Sources
+    - Tests
+


### PR DESCRIPTION
With this change, running swiftLint from the terminal will no more require specifiyng the folders to run on. Running `$ swiftlint` from the terminal will automatically only run the linter on the `Sources` and `Tests` folders.

- Moved the `.swiftLint.yml` to the route folder.
- Added an inclusion rules to scoupe linting to only `Sources` and `Tests` folders.