### PR TITLE
Really fix font and asset copying.

### DIFF
--- a/Sources/Ignite/Extensions/URL-DecodedPath.swift
+++ b/Sources/Ignite/Extensions/URL-DecodedPath.swift
@@ -1,0 +1,15 @@
+//
+// URL-DecodedPath.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+
+extension URL {
+    /// The URL path without percent encoding.
+    var decodedPath: String {
+        self.path(percentEncoded: false)
+    }
+}

--- a/Sources/Ignite/Framework/DecodeAction.swift
+++ b/Sources/Ignite/Framework/DecodeAction.swift
@@ -28,7 +28,7 @@ public struct DecodeAction {
     public func url(forResource resource: String) -> URL? {
         let fullURL = sourceDirectory.appending(path: "Resources/\(resource)")
 
-        if FileManager.default.fileExists(atPath: fullURL.path(percentEncoded: false)) {
+        if FileManager.default.fileExists(atPath: fullURL.decodedPath) {
             return fullURL
         } else {
             return nil

--- a/Sources/Ignite/Publishing/PublishingContext-Copying.swift
+++ b/Sources/Ignite/Publishing/PublishingContext-Copying.swift
@@ -31,7 +31,7 @@ extension PublishingContext {
 
     /// Copies all files from the project's "Assets" directory to the build output's root directory.
     func copyAssets() {
-        guard FileManager.default.fileExists(atPath: assetsDirectory.path()) else {
+        guard FileManager.default.fileExists(atPath: assetsDirectory.decodedPath) else {
             return
         }
 
@@ -54,7 +54,7 @@ extension PublishingContext {
 
     /// Copies custom font files from the project's "Fonts" directory to the build output's "fonts" directory.
     func copyFonts() {
-        guard FileManager.default.fileExists(atPath: fontsDirectory.path()) else {
+        guard FileManager.default.fileExists(atPath: fontsDirectory.decodedPath) else {
             return
         }
 

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -216,14 +216,14 @@ final class PublishingContext {
         copyAssets()
         copyFonts()
 
-        let themesPath = buildDirectory.appending(path: "css/themes.min.css").path(percentEncoded: false)
+        let themesPath = buildDirectory.appending(path: "css/themes.min.css").decodedPath
 
         if !FileManager.default.fileExists(atPath: themesPath) {
             copy(resource: "css/themes.min.css")
         }
 
         if AnimationManager.default.hasAnimations {
-            let animationsPath = buildDirectory.appending(path: "css/animations.min.css").path()
+            let animationsPath = buildDirectory.appending(path: "css/animations.min.css").decodedPath
             if !FileManager.default.fileExists(atPath: animationsPath) {
                 copy(resource: "css/animations.min.css")
             }


### PR DESCRIPTION
Relates to #246. We should thoroughly investigate this percent encoding issue with `URL` throughout the codebase.