### PR TITLE
Stabilize ID used in animation class names.

### DIFF
--- a/Sources/Ignite/Framework/Animations/Animatable.swift
+++ b/Sources/Ignite/Framework/Animations/Animatable.swift
@@ -8,7 +8,7 @@
 import OrderedCollections
 
 /// A protocol that defines the core animation capabilities for Ignite's animation system.
-public protocol Animatable {
+public protocol Animatable: Hashable {
     /// The event that triggers the animation.
     var trigger: AnimationTrigger { get set }
 
@@ -36,6 +36,10 @@ public protocol Animatable {
 }
 
 public extension Animatable {
+    var id: String {
+        Self.id
+    }
+
     static var id: String {
         String(describing: self).truncatedHash
     }

--- a/Sources/Ignite/Framework/Animations/AnimatableData.swift
+++ b/Sources/Ignite/Framework/Animations/AnimatableData.swift
@@ -6,7 +6,7 @@
 //
 
 /// A basic animation type that transitions a single CSS property from one value to another.
-public struct AnimatableData {
+public struct AnimatableData: Hashable {
     /// The starting value for the animated property
     var initial: String
 

--- a/Sources/Ignite/Framework/Animations/AnimatableProperty.swift
+++ b/Sources/Ignite/Framework/Animations/AnimatableProperty.swift
@@ -6,7 +6,7 @@
 //
 
 /// CSS properties that can be animated
-public enum AnimatableProperty: String {
+public enum AnimatableProperty: String, Hashable {
     /// Controls the aspect ratio of an element
     case aspectRatio = "aspect-ratio"
     /// Controls the background properties of an element

--- a/Sources/Ignite/Framework/Animations/Animation.swift
+++ b/Sources/Ignite/Framework/Animations/Animation.swift
@@ -24,7 +24,7 @@ import OrderedCollections
 ///        animation.color(.foreground, to: .white)
 ///    }
 /// ```
-public struct Animation: Animatable {
+public struct Animation: Animatable, Hashable {
     /// The collection of frames that define the animation sequence
     var frames: [Frame]
 

--- a/Sources/Ignite/Framework/Animations/AnimationClassGenerator-Keyframes.swift
+++ b/Sources/Ignite/Framework/Animations/AnimationClassGenerator-Keyframes.swift
@@ -17,9 +17,9 @@ extension AnimationClassGenerator {
         if triggerMap[.click] != nil {
             baseProperties.insert("cursor: pointer")
         }
-
+        let baseClass = "animation-" + animation.id
         let timing = getAnimationTiming(animation)
-        baseProperties.insert("animation: \(name)-appear \(timing)")
+        baseProperties.insert("animation: \(baseClass)-appear \(timing)")
         return baseProperties
     }
 
@@ -46,23 +46,24 @@ extension AnimationClassGenerator {
         let fillModeClass = fillMode(for: animation, timing: timing, iterations: iterationCount)
 
         let animationRepeat = animation.repeatCount != 1 ? " " + iterationCount : ""
+        let baseClass = "animation-" + animation.id
 
         return """
-        .\(name)-hover {
+        .\(baseClass)-hover {
             transform-style: preserve-3d;
             \(baseState)
         }
 
-        .\(name)-hover:hover {
-            animation: \(name)-hover \(timing) \(animation.direction.rawValue)\(animationRepeat);
+        .\(baseClass)-hover:hover {
+            animation: \(baseClass)-hover \(timing) \(animation.direction.rawValue)\(animationRepeat);
         }
 
-        .\(name)-hover:not(:hover) {
+        .\(baseClass)-hover:not(:hover) {
             \(postHoverState ?? "")
         }
         \(fillModeClass)
 
-        @keyframes \(name)-hover {
+        @keyframes \(baseClass)-hover {
             \(buildKeyframeContent(animation))
         }
         """
@@ -138,7 +139,7 @@ extension AnimationClassGenerator {
             }
         }
 
-        return buildClickOutput(properties)
+        return buildClickOutput(properties, id: animation.id)
     }
 
     private func baseState(for animation: Animation) -> String {
@@ -158,14 +159,15 @@ extension AnimationClassGenerator {
     private func fillMode(for animation: Animation, timing: String, iterations: String) -> String {
         if animation.fillMode == .backwards || animation.fillMode == .both {
             let count = animation.repeatCount != 1 ? " " + iterations : ""
+            let baseClass = "animation-" + animation.id
             return """
 
-            .\(name)-hover.fill-\(elementID)-\(animation.fillMode) {
-                animation: \(name)-hover \(timing) \(animation.direction.rawValue) \(animation.fillMode)\(count);
+            .\(baseClass)-hover.fill-\(animation.id)-\(animation.fillMode) {
+                animation: \(baseClass)-hover \(timing) \(animation.direction.rawValue) \(animation.fillMode)\(count);
                 animation-play-state: paused;
             }
 
-            .\(name)-hover.fill-\(elementID)-\(animation.fillMode):hover {
+            .\(baseClass)-hover.fill-\(animation.id)-\(animation.fillMode):hover {
                 animation-play-state: running;
             }
             """

--- a/Sources/Ignite/Framework/Animations/AnimationClassGenerator-Transitions.swift
+++ b/Sources/Ignite/Framework/Animations/AnimationClassGenerator-Transitions.swift
@@ -37,7 +37,7 @@ extension AnimationClassGenerator {
             }
         }
 
-        return buildClickOutput(properties)
+        return buildClickOutput(properties, id: transition.id)
     }
 
     /// Generates CSS classes for appear-triggered transitions
@@ -54,8 +54,10 @@ extension AnimationClassGenerator {
             "\(data.property.rawValue): \(data.final)"
         }
 
+        let baseClass = "animation-" + transition.id
+
         return """
-        .\(name).appeared {
+        .\(baseClass).appeared {
             transition: \(transitions.joined(separator: ", "));
             \(properties.joined(separator: ";\n        "));
         }
@@ -96,13 +98,15 @@ extension AnimationClassGenerator {
             "\(data.property.rawValue): \(data.final)"
         }
 
+        let baseClass = "animation-" + transition.id
+
         return """
-        .\(name)-transform {
+        .\(baseClass)-transform {
             transform-style: preserve-3d;
             transition: \(transitions.joined(separator: ", "));
         }
 
-        .\(name)-transform:hover {
+        .\(baseClass)-transform:hover {
             \(hoverProperties.joined(separator: ";\n        "));
         }
         """

--- a/Sources/Ignite/Framework/Animations/AnimationClassGenerator.swift
+++ b/Sources/Ignite/Framework/Animations/AnimationClassGenerator.swift
@@ -10,14 +10,8 @@
 /// `AnimationClassGenerator` converts Ignite animations into CSS classes, handling different
 /// trigger types (hover, click, appear) and generating appropriate keyframes and transition rules.
 struct AnimationClassGenerator {
-    /// The ID of the element receiving animations
-    let elementID: String
-
     /// A mapping of trigger types to their corresponding resolved animations
     let triggerMap: OrderedDictionary<AnimationTrigger, any Animatable>
-
-    /// The base name for the generated CSS classes
-    var name: String { "animation-" + elementID }
 
     /// Holds CSS properties and transitions for both clicked and unclicked states,
     /// separated into transform and non-transform properties. Transform properties
@@ -36,17 +30,17 @@ struct AnimationClassGenerator {
     /// Formats CSS output for click animations, creating separate rules for transform and non-transform properties
     /// - Parameter properties: The collected CSS properties and transitions
     /// - Returns: A string containing the formatted CSS classes
-    func buildClickOutput(_ properties: ClickAnimationProperties) -> String {
+    func buildClickOutput(_ properties: ClickAnimationProperties, id animationID: String) -> String {
         var output = ""
-
+        let baseClass = "animation-" + animationID
         if !properties.nonTransformProperties.isEmpty {
             output += """
-            .\(name).clicked .click-\(elementID) {
+            .\(baseClass).clicked .click-\(animationID) {
                 transition: \(properties.nonTransformTransitions.joined(separator: ", "));
                 \(properties.nonTransformProperties.joined(separator: ";\n        "));
             }
 
-            .\(name).unclicked .click-\(elementID)  {
+            .\(baseClass).unclicked .click-\(animationID)  {
                 transition: \(properties.nonTransformTransitions.joined(separator: ", "));
                 \(properties.unclickedNonTransformProperties.joined(separator: ";\n        "));
             }
@@ -59,12 +53,12 @@ struct AnimationClassGenerator {
             }
 
             output += """
-            .\(name).clicked {
+            .\(baseClass).clicked {
                 transition: \(properties.transformTransitions.joined(separator: ", "));
                 \(properties.transformProperties.joined(separator: ";\n        "));
             }
 
-            .\(name).unclicked {
+            .\(baseClass).unclicked {
                 transition: \(properties.transformTransitions.joined(separator: ", "));
                 \(properties.unclickedTransformProperties.joined(separator: ";\n        "));
             }
@@ -155,9 +149,10 @@ struct AnimationClassGenerator {
         let appearedProperties = getAppearedProperties()
         let joinedProperties = baseProperties.joined(separator: ";\n        ")
         let baseClassProperties = baseProperties.isEmpty ? "" : "\n        \(joinedProperties);\n    "
+        let className = "animation-" + animation.id
 
         let baseClass = """
-        .\(name) {\(baseClassProperties)}
+        .\(className) {\(baseClassProperties)}
         """
 
         // Only add appeared class if we have properties to set
@@ -165,7 +160,7 @@ struct AnimationClassGenerator {
             let joinedAppearedProperties = appearedProperties.joined(separator: ";\n        ")
 
             return baseClass + "\n\n" + """
-            .\(name).appeared {
+            .\(className).appeared {
                 \(joinedAppearedProperties);
             }
             """
@@ -194,16 +189,17 @@ struct AnimationClassGenerator {
 
         let repeatCount = animation.repeatCount == .infinity ? "infinite" : String(animation.repeatCount)
         let repeatString = animation.repeatCount != 1 ? "animation-iteration-count: \(repeatCount);" : ""
+        let baseClass = "animation-" + animation.id
 
         return """
-        .\(name).appeared {
-            animation: \(name)-appear \(timing);
+        .\(baseClass).appeared {
+            animation: \(baseClass)-appear \(timing);
             animation-fill-mode: \(animation.fillMode.rawValue);
             animation-direction: \(animation.direction.rawValue);
             \(repeatString)
         }
 
-        @keyframes \(name)-appear {
+        @keyframes \(baseClass)-appear {
             \(keyframeContent)
         }
         """

--- a/Sources/Ignite/Framework/Animations/AnimationDirection.swift
+++ b/Sources/Ignite/Framework/Animations/AnimationDirection.swift
@@ -6,7 +6,7 @@
 //
 
 /// Specifies the direction of an animation's playback.
-public enum AnimationDirection: String, Sendable {
+public enum AnimationDirection: String, Hashable, Sendable {
     /// Plays the animation normally from start to finish.
     case automatic = "normal"
 

--- a/Sources/Ignite/Framework/Animations/AnimationFrame.swift
+++ b/Sources/Ignite/Framework/Animations/AnimationFrame.swift
@@ -9,7 +9,7 @@ public typealias AnimationFrame = Animation.Frame
 
 public extension Animation {
     /// A single keyframe in an animation sequence.
-    struct Frame {
+    struct Frame: Hashable {
         /// The position in the animation timeline, between `0%` and `100%`
         let position: Percentage
 

--- a/Sources/Ignite/Framework/Animations/AnimationManager.swift
+++ b/Sources/Ignite/Framework/Animations/AnimationManager.swift
@@ -22,9 +22,7 @@ final class AnimationManager {
     private var animations: [String: OrderedDictionary<AnimationTrigger, any Animatable>] = [:]
 
     /// Returns true if any animations have been registered
-    var hasAnimations: Bool {
-        !animations.isEmpty
-    }
+    var hasAnimations: Bool { !animations.isEmpty }
 
     /// Private initializer to enforce singleton pattern.
     private init() {}
@@ -57,22 +55,19 @@ final class AnimationManager {
         animations[elementID]?[trigger]
     }
 
-    /// Returns all animations registered for a specific HTML element.
-    /// - Parameter elementID: The unique identifier of the HTML element
-    /// - Returns: An array of animations associated with the element, or an empty array if none exist
-    func getAnimations(for elementID: String) -> [any Animatable] {
-        animations[elementID]?.values.map(\.self) ?? []
-    }
-
     /// Generates and writes CSS for all registered animations to a file.
     /// - Parameter file: The URL where the CSS file should be written
     func write(to file: URL) {
-        let cssBlocks = animations.map { elementID, triggerMap in
-            let generator = AnimationClassGenerator(elementID: elementID, triggerMap: triggerMap)
+        let cssBlocks = animations.map { _, triggerMap in
+            let generator = AnimationClassGenerator(triggerMap: triggerMap)
             return generator.build()
         }
 
-        let css = cssBlocks.joined(separator: "\n\n")
-        try? css.write(to: file, atomically: true, encoding: .utf8)
+        do {
+            let css = cssBlocks.joined(separator: "\n\n")
+            try css.write(to: file, atomically: true, encoding: .utf8)
+        } catch {
+            PublishingContext.default.addError(.failedToWriteFile("css/animations.min.css"))
+        }
     }
 }

--- a/Sources/Ignite/Framework/Animations/AnimationTrigger.swift
+++ b/Sources/Ignite/Framework/Animations/AnimationTrigger.swift
@@ -6,7 +6,7 @@
 //
 
 /// Defines the events that can trigger an animation on an HTML element.
-public enum AnimationTrigger: String {
+public enum AnimationTrigger: String, Hashable {
     /// Animation triggers when the element is clicked/tapped
     /// - Note: Adds cursor: pointer and click event listener
     case click

--- a/Sources/Ignite/Framework/Animations/FillMode.swift
+++ b/Sources/Ignite/Framework/Animations/FillMode.swift
@@ -6,7 +6,7 @@
 //
 
 /// Specifies how values persist before and after an animation
-public enum FillMode: String, Sendable {
+public enum FillMode: String, Hashable, Sendable {
     /// No fill mode needed
     case none
     /// Retains the values set by the last keyframe

--- a/Sources/Ignite/Framework/Animations/TimingCurve.swift
+++ b/Sources/Ignite/Framework/Animations/TimingCurve.swift
@@ -6,7 +6,7 @@
 //
 
 /// Defines the available timing functions for animations
-public enum TimingCurve: CSSRepresentable {
+public enum TimingCurve: CSSRepresentable, Hashable {
     /// Spring animation (response: 0.55, dampingFraction: 1.0)
     case automatic
     /// Linear timing with constant speed

--- a/Sources/Ignite/Framework/Animations/Transition.swift
+++ b/Sources/Ignite/Framework/Animations/Transition.swift
@@ -8,7 +8,7 @@
 import OrderedCollections
 
 /// The main animation configuration type that provides a flexible way to define CSS animations
-public struct Transition: Animatable {
+public struct Transition: Animatable, Hashable {
     /// The CSS properties being animated and their values
     var data: [AnimatableData]
     /// Additional non-animated CSS properties

--- a/Sources/Ignite/Modifiers/AnimationModifier.swift
+++ b/Sources/Ignite/Modifiers/AnimationModifier.swift
@@ -65,7 +65,7 @@ public extension HTML {
     ///   - direction: Optional direction for keyframe animations (e.g., alternate, reverse)
     ///   - trigger: The event that triggers this animation (.hover, .click, or .appear)
     /// - Returns: The modified HTML element with animation containers and classes applied
-    internal func applyAnimation(
+    fileprivate func applyAnimation(
         _ animation: some Animatable,
         direction: AnimationDirection?,
         trigger: AnimationTrigger
@@ -128,10 +128,10 @@ public extension HTML {
         return self
     }
 
-    func createBaseAnimation(
+    private func createBaseAnimation(
         for animation: any Animatable,
         direction: AnimationDirection?,
-        existingAnimation: Animatable?
+        existingAnimation: (any Animatable)?
     ) -> any Animatable {
         if let basicAnim = animation as? Transition {
             var copy = basicAnim
@@ -167,11 +167,11 @@ public extension HTML {
         in existingContainers: Set<String>,
         styles wrapperStyles: OrderedSet<InlineStyle>
     ) {
-        let animationName = "animation-\(self.id)"
+        let animationName = "animation-\(animation.id)"
 
         for trigger in triggers {
             switch trigger {
-            case .click where !existingContainers.contains("click-\(self.id)"):
+            case .click where !existingContainers.contains("click-\(animation.id)"):
                 // Add click handler to a new container, or the appear container
                 // if it exists to avoid duplicate class assignments
                 if !existingContainers.contains(animationName) {
@@ -199,7 +199,7 @@ public extension HTML {
                 // Inner click-specific container
                 attributes.append(containerAttributes: ContainerAttributes(
                     type: .animation,
-                    classes: ["click-\(self.id)"]
+                    classes: ["click-\(animation.id)"]
                 ))
 
             case .hover where !existingContainers.contains("\(animationName)-hover"):
@@ -215,7 +215,7 @@ public extension HTML {
 
                 if let animation = animation as? Animation,
                    animation.fillMode == .backwards || animation.fillMode == .both {
-                    classes.append("fill-\(self.id)-\(animation.fillMode.rawValue)")
+                    classes.append("fill-\(animation.id)-\(animation.fillMode.rawValue)")
                 }
 
                 attributes.append(containerAttributes: ContainerAttributes(


### PR DESCRIPTION
The class names generated by the `animation()` and `transition()` modifiers now use the `Animatable` object's ID rather than the `HTML` element's internal ID. The stabilized class name will eliminate noise among diffs.

Making `Animatable` conform to `Hashable` ultimately wasn't necessary, but I've left the conformance in to make the protocol more flexible going forward.