### PR TITLE
Content: Fix Tables missing bootstrap table class

### DIFF
--- a/Sources/Ignite/Rendering/Markdown/MarkdownToHTML.swift
+++ b/Sources/Ignite/Rendering/Markdown/MarkdownToHTML.swift
@@ -343,7 +343,7 @@ public struct MarkdownToHTML: MarkdownRenderer, MarkupVisitor {
         var output = ""
 
         for child in tableHead.children {
-            output += "<th>"
+            output += "<th scope=\"col\">"
             output += visit(child)
             output += "</th>"
         }

--- a/Sources/Ignite/Rendering/Markdown/MarkdownToHTML.swift
+++ b/Sources/Ignite/Rendering/Markdown/MarkdownToHTML.swift
@@ -317,7 +317,7 @@ public struct MarkdownToHTML: MarkdownRenderer, MarkupVisitor {
     /// - Returns: A HTML <table> element, with <thead> and
     /// <tbody> if they are provided.
     public mutating func visitTable(_ table: Markdown.Table) -> String {
-        var output = "<table>"
+        var output = "<table class=\"table\">"
 
         if table.head.childCount > 0 {
             output += "<thead>"

--- a/Tests/IgniteTesting/Framework/MarkdownRenderer.swift
+++ b/Tests/IgniteTesting/Framework/MarkdownRenderer.swift
@@ -152,10 +152,10 @@ struct MarkdownRendererTests {
         let element = MarkdownToHTML(markdown: markdown, removeTitleFromBody: false)
 
         #expect(element.body == """
-        <table>\
+        <table class="table">\
         <thead>\
-        <th>Title 1</th>\
-        <th>Title 2</th>\
+        <th scope="col">Title 1</th>\
+        <th scope="col">Title 2</th>\
         </thead>\
         <tbody>\
         <tr>\


### PR DESCRIPTION
I have a md table in some of my content, and noticed it doesn't nicely layout its contents when rendered. Some quick googling led me here to the official [Bootstrap Table Documentation](https://getbootstrap.com/docs/4.0/content/tables/#examples) which states that tables are not handled by Bootstrap unless they have the `table` class.

So I've added this (along with the `scope="col"` attribute for table headers)