### PR TITLE
Fix `URL` path creation in `Script` and `Image`.

### DIFF
--- a/Sources/Ignite/Elements/Form.swift
+++ b/Sources/Ignite/Elements/Form.swift
@@ -186,7 +186,7 @@ public struct Form: BlockHTML {
 
         // Add custom SendFox JavaScript if needed.
         if case .sendFox = action.service {
-            formOutput += Script(file: "https://cdn.sendfox.com/js/form.js")
+            formOutput += Script(file: URL(static: "https://cdn.sendfox.com/js/form.js"))
                 .customAttribute(name: "charset", value: "utf-8")
                 .render()
         }

--- a/Sources/Ignite/Elements/Image.swift
+++ b/Sources/Ignite/Elements/Image.swift
@@ -95,7 +95,7 @@ public struct Image: BlockHTML, InlineHTML, LazyLoadable {
 
     /// Renders a user image into the current publishing context.
     /// - Parameters:
-    ///   - icon: The user image to render.
+    ///   - image: The user image to render.
     ///   - description: The accessibility label to use.
     ///   - context: The active publishing context.
     /// - Returns: The HTML for this element.
@@ -122,8 +122,8 @@ public struct Image: BlockHTML, InlineHTML, LazyLoadable {
 
         if let systemImage {
             return render(icon: systemImage, description: description ?? "")
-        } else if let name {
-            return render(image: name, description: description ?? "")
+        } else if let name = name?.trimmingPrefix("/") {
+            return render(image: String(name), description: description ?? "")
         } else {
             publishingContext.addWarning("""
             Creating an image with no name or icon should not be possible. \

--- a/Sources/Ignite/Elements/Image.swift
+++ b/Sources/Ignite/Elements/Image.swift
@@ -102,8 +102,9 @@ public struct Image: BlockHTML, InlineHTML, LazyLoadable {
     private func render(image: String, description: String) -> String {
         var attributes = attributes
         attributes.selfClosingTag = "img"
+        let path = publishingContext.site.url.appending(path: image).decodedPath
         attributes.append(customAttributes:
-            .init(name: "src", value: "\(publishingContext.site.url.path)\(image)"),
+            .init(name: "src", value: path),
             .init(name: "alt", value: description)
         )
         return attributes.description()

--- a/Sources/Ignite/Elements/Link.swift
+++ b/Sources/Ignite/Elements/Link.swift
@@ -204,9 +204,9 @@ public struct Link: BlockHTML, InlineHTML, NavigationItem, DropdownElement {
     private func renderStandardLink() -> String {
         var linkAttributes = attributes.appending(classes: linkClasses)
 
-        // char[0] of the 'url' is '/' for an asset; not for a site URL
-        let basePath = url.starts(with: "/") ? publishingContext.site.url.path : ""
-        linkAttributes.tag = "a href=\"\(basePath)\(url)\""
+        let url = String(url.trimmingPrefix("/"))
+        let path = publishingContext.site.url.appending(path: url).decodedPath
+        linkAttributes.tag = "a href=\"\(path)\""
         linkAttributes.closingTag = "a"
         return linkAttributes.description(wrapping: content.render())
     }

--- a/Sources/Ignite/Elements/Link.swift
+++ b/Sources/Ignite/Elements/Link.swift
@@ -204,8 +204,12 @@ public struct Link: BlockHTML, InlineHTML, NavigationItem, DropdownElement {
     private func renderStandardLink() -> String {
         var linkAttributes = attributes.appending(classes: linkClasses)
 
-        let url = String(url.trimmingPrefix("/"))
-        let path = publishingContext.site.url.appending(path: url).decodedPath
+        guard let url = URL(string: url) else {
+            publishingContext.addWarning("One of your links uses an invalid URL.")
+            return ""
+        }
+
+        let path = publishingContext.path(for: url)
         linkAttributes.tag = "a href=\"\(path)\""
         linkAttributes.closingTag = "a"
         return linkAttributes.description(wrapping: content.render())

--- a/Sources/Ignite/Elements/Script.swift
+++ b/Sources/Ignite/Elements/Script.swift
@@ -25,10 +25,13 @@ public struct Script: BlockHTML, HeadElement {
     /// The external file to load.
     private var file: String?
 
+    /// Whether the external file is local or remote.
+    private var isRemoteFile = false
+
     /// Direct, inline JavaScript code to execute.
     private var code: String?
 
-    /// Creates a new script that references an external file.
+    /// Creates a new script that references a local file.
     /// - Parameter file: The URL of the file to load.
     public init(file: String) {
         self.file = file
@@ -38,6 +41,7 @@ public struct Script: BlockHTML, HeadElement {
     /// - Parameter file: The URL of the file to load.
     public init(file: URL) {
         self.file = file.absoluteString
+        self.isRemoteFile = !file.isFileURL
     }
 
     /// Embeds some custom, inline JavaScript on this page.
@@ -52,7 +56,9 @@ public struct Script: BlockHTML, HeadElement {
         attributes.tag = "script"
 
         if let file {
-            attributes.append(customAttributes: .init(name: "src", value: "\(publishingContext.site.url.path)\(file)"))
+            let filePath = isRemoteFile ?
+                file : publishingContext.site.url.appending(path: file).decodedPath
+            attributes.append(customAttributes: .init(name: "src", value: filePath))
             return attributes.description()
         } else if let code {
             return attributes.description(wrapping: code)

--- a/Sources/Ignite/Elements/Script.swift
+++ b/Sources/Ignite/Elements/Script.swift
@@ -23,10 +23,7 @@ public struct Script: BlockHTML, HeadElement {
     public var columnWidth = ColumnWidth.automatic
 
     /// The external file to load.
-    private var file: String?
-
-    /// Whether the external file is local or remote.
-    private var isRemoteFile = false
+    private var file: URL?
 
     /// Direct, inline JavaScript code to execute.
     private var code: String?
@@ -34,14 +31,13 @@ public struct Script: BlockHTML, HeadElement {
     /// Creates a new script that references a local file.
     /// - Parameter file: The URL of the file to load.
     public init(file: String) {
-        self.file = file
+        self.file = URL(string: file)
     }
 
     /// Creates a new script that references an external file.
     /// - Parameter file: The URL of the file to load.
     public init(file: URL) {
-        self.file = file.absoluteString
-        self.isRemoteFile = !file.isFileURL
+        self.file = file
     }
 
     /// Embeds some custom, inline JavaScript on this page.
@@ -56,10 +52,8 @@ public struct Script: BlockHTML, HeadElement {
         attributes.tag = "script"
 
         if let file {
-            let safePath = String(file.trimmingPrefix("/"))
-            let filePath = isRemoteFile ?
-            safePath : publishingContext.site.url.appending(path: safePath).decodedPath
-            attributes.append(customAttributes: .init(name: "src", value: filePath))
+            let path = publishingContext.path(for: file)
+            attributes.append(customAttributes: .init(name: "src", value: path))
             return attributes.description()
         } else if let code {
             return attributes.description(wrapping: code)

--- a/Sources/Ignite/Elements/Script.swift
+++ b/Sources/Ignite/Elements/Script.swift
@@ -56,8 +56,9 @@ public struct Script: BlockHTML, HeadElement {
         attributes.tag = "script"
 
         if let file {
+            let safePath = String(file.trimmingPrefix("/"))
             let filePath = isRemoteFile ?
-                file : publishingContext.site.url.appending(path: file).decodedPath
+            safePath : publishingContext.site.url.appending(path: safePath).decodedPath
             attributes.append(customAttributes: .init(name: "src", value: filePath))
             return attributes.description()
         } else if let code {

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -128,6 +128,20 @@ final class PublishingContext {
         }
     }
 
+    /// Converts a URL to a site-relative path string.
+    /// - Parameter url: The URL to convert.
+    /// - Returns: A string path, either preserving remote URLs or
+    /// making local URLs relative to the site root.
+    func path(for url: URL) -> String {
+        let isRemote = !url.isFileURL
+        let path = String(url.relativeString)
+        return if isRemote {
+            path
+        } else {
+            site.url.appending(path: path).decodedPath
+        }
+    }
+
     /// Adds a warning during a site build.
     /// - Parameter message: The warning string to add.
     func addWarning(_ message: String) {

--- a/Tests/IgniteTesting/Elements/Card.swift
+++ b/Tests/IgniteTesting/Elements/Card.swift
@@ -40,7 +40,7 @@ struct CardTests {
         let output = element.render()
 
         #expect(output == """
-        <div class="card"><img alt="" src="dog.jpg" class="card-img-top" />\
+        <div class="card"><img alt="" src="/dog.jpg" class="card-img-top" />\
         <div class="card-body">Some text wrapped in a card</div></div>
         """)
     }
@@ -112,7 +112,7 @@ struct CardTests {
 
         #expect(output == """
         <div class="card"><div class="card-body">Placeholder</div>\
-        <img alt="" src="image.jpg" class="card-img-bottom" /></div>
+        <img alt="" src="/image.jpg" class="card-img-bottom" /></div>
         """)
     }
 
@@ -126,7 +126,7 @@ struct CardTests {
         let output = element.render()
 
         #expect(output == """
-        <div class="card"><img alt="" src="image.jpg" class="card-img-top" />\
+        <div class="card"><img alt="" src="/image.jpg" class="card-img-top" />\
         <div class="card-body">Placeholder</div></div>
         """)
     }
@@ -141,7 +141,7 @@ struct CardTests {
         let output = element.render()
 
         #expect(output == """
-        <div class="card"><img alt="" src="image.jpg" class="card-img" />\
+        <div class="card"><img alt="" src="/image.jpg" class="card-img" />\
         <div class="align-content-start card-img-overlay text-start">Placeholder</div></div>
         """)
     }

--- a/Tests/IgniteTesting/Elements/Image.swift
+++ b/Tests/IgniteTesting/Elements/Image.swift
@@ -13,19 +13,26 @@ import Testing
 /// Tests for the `Image` element.
 @Suite("Image Tests")
 @MainActor struct ImageTests {
-    static let sites: [any Site] = [TestSite(), TestSubsite()]
+    init() throws {
+        try PublishingContext.initialize(for: TestSite(), from: #filePath)
+    }
 
-    @Test("Image Test", arguments:
-        [(path: "/images/example.jpg", description: "Example image")],
-        await Self.sites)
-    func named(image: (path: String, description: String), for site: any Site) async throws {
-        try PublishingContext.initialize(for: site, from: #filePath)
-
-        let element = Image(image.path, description: image.description)
+    @Test("Local Image", arguments: ["/images/example.jpg"], ["Example image"])
+    func named(file: String, description: String) async throws {
+        let element = Image(file, description: description)
         let output = element.render()
 
-        let expectedPath = site.url.appending(path: image.path).decodedPath
-        #expect(output == "<img alt=\"Example image\" src=\"\(expectedPath)\" />")
+        let expectedPath = PublishingContext.default.path(for: URL(string: file)!)
+        #expect(output == "<img alt=\"\(description)\" src=\"\(expectedPath)\" />")
+    }
+
+    @Test("Remote Image", arguments: ["https://example.com"], ["Example image"])
+    func named(url: String, description: String) async throws {
+        let element = Image(url, description: description)
+        let output = element.render()
+
+        let expectedPath = PublishingContext.default.path(for: URL(string: url)!)
+        #expect(output == "<img alt=\"\(description)\" src=\"\(expectedPath)\" />")
     }
 
     @Test("Icon Image Test", arguments: ["browser-safari"], ["Safari logo"])

--- a/Tests/IgniteTesting/Elements/Image.swift
+++ b/Tests/IgniteTesting/Elements/Image.swift
@@ -24,7 +24,7 @@ import Testing
         let element = Image(image.path, description: image.description)
         let output = element.render()
 
-        let expectedPath = site.url.path == "/" ? image.path : "\(site.url.path)\(image.path)"
+        let expectedPath = site.url.appending(path: image.path).decodedPath
         #expect(output == "<img alt=\"Example image\" src=\"\(expectedPath)\" />")
     }
 

--- a/Tests/IgniteTesting/Elements/Link.swift
+++ b/Tests/IgniteTesting/Elements/Link.swift
@@ -26,7 +26,7 @@ import Testing
 
         let element = Link(link.description, target: link.target)
         let output = element.render()
-        let expectedPath = site.url.path == "/" ? link.target : "\(site.url.path)\(link.target)"
+        let expectedPath = PublishingContext.default.path(for: URL(string: link.target)!)
 
         #expect(
             output == """
@@ -46,9 +46,7 @@ import Testing
         let element = Link("This is a test", target: page).linkStyle(.button)
         let output = element.render()
 
-        let expectedPath = site.url.pathComponents.count <= 1 ?
-            "/test-layout" :
-            "\(site.url.path)/test-subsite-layout"
+        let expectedPath = PublishingContext.default.path(for: URL(string: page.path)!)
 
         #expect(output == "<a href=\"\(expectedPath)\" class=\"btn btn-primary\">This is a test</a>")
     }
@@ -65,9 +63,7 @@ import Testing
             })
         let output = element.render()
 
-        let expectedPath = site.url.pathComponents.count <= 1 ?
-            "/test-layout" :
-            "\(site.url.path)/test-subsite-layout"
+        let expectedPath = PublishingContext.default.path(for: URL(string: page.path)!)
 
         #expect(
             output == """
@@ -86,9 +82,7 @@ import Testing
 
         let element = Link("Link with warning role.", target: page).role(.warning)
         let output = element.render()
-        let expectedPath = site.url.pathComponents.count <= 1 ?
-        "/test-layout" :
-        "\(site.url.path)/test-subsite-layout"
+        let expectedPath = PublishingContext.default.path(for: URL(string: page.path)!)
 
         #expect(
             output == """

--- a/Tests/IgniteTesting/Elements/Script.swift
+++ b/Tests/IgniteTesting/Elements/Script.swift
@@ -24,14 +24,25 @@ import Testing
         #expect(output == "<script>javascript code</script>")
     }
 
-    @Test("File Test", arguments: ["/code.js"], await Self.sites)
+    @Test("Local File", arguments: ["/code.js"], await Self.sites)
     func file(scriptFile: String, site: any Site) async throws {
         try PublishingContext.initialize(for: site, from: #filePath)
 
         let element = Script(file: scriptFile)
         let output = element.render()
 
-        let expectedPath = site.url.pathComponents.count <= 1 ? scriptFile : "\(site.url.path)\(scriptFile)"
+        let expectedPath = PublishingContext.default.path(for: URL(string: scriptFile)!)
+        #expect(output == "<script src=\"\(expectedPath)\"></script>")
+    }
+
+    @Test("Remote File", arguments: ["https://example.com"], await Self.sites)
+    func file(remoteScript: String, site: any Site) async throws {
+        try PublishingContext.initialize(for: site, from: #filePath)
+
+        let element = Script(file: remoteScript)
+        let output = element.render()
+
+        let expectedPath = PublishingContext.default.path(for: URL(string: remoteScript)!)
         #expect(output == "<script src=\"\(expectedPath)\"></script>")
     }
 
@@ -44,7 +55,7 @@ import Testing
             .customAttribute(name: "custom", value: "part")
         let output = element.render()
 
-        let expectedPath = site.url.pathComponents.count <= 1 ? scriptFile : "\(site.url.path)\(scriptFile)"
+        let expectedPath = PublishingContext.default.path(for: URL(string: scriptFile)!)
         #expect(output == "<script custom=\"part\" src=\"\(expectedPath)\" data-key=\"value\"></script>")
     }
 }


### PR DESCRIPTION
Currently treating website URLs as if they are files when generating the path.