### PR TITLE
Add SiteTests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 Package.resolved
 /.build
 /Packages
+Tests/IgniteTesting/TestWebsitePackage/Build
+Tests/IgniteTesting/TestWebsitePackage/Content/*.md
 xcuserdata/
 DerivedData/
 .swiftpm/configuration/registries.json

--- a/Tests/IgniteTesting/Publishing/Site.swift
+++ b/Tests/IgniteTesting/Publishing/Site.swift
@@ -1,0 +1,83 @@
+//
+// Site.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+import Testing
+
+@testable import Ignite
+
+/// Tests for the `Site` type.
+@Suite("Site Tests", .serialized)
+@MainActor
+struct SiteTests {
+    
+    private let package = TestPackage()
+    
+    @Test("Site published given there is no Markdown content")
+    func publishingWithNoMarkdownContent() async throws {
+        let markdownFileURL = package.contentDirectoryURL.appending(path: "story-with-valid-metadata.md")
+        let markdownContent = """
+        ---
+        layout: TestStory
+        lastModified: 2020-03-30 16:37
+        ---
+        
+        # Story with valid metadata
+        """
+        
+        try markdownContent.write(to: markdownFileURL, atomically: false, encoding: .utf8)
+        
+        try await TestSitePublisher().publish()
+        
+        #expect(package.checkIndexFileExists() == true)
+        
+        try FileManager.default.removeItem(at: markdownFileURL)
+        try FileManager.default.removeItem(at: package.buildDirectoryURL)
+    }
+    
+    @Test("Site published when Markdown content contains invalid lastModified date")
+    func publishingWithInvalidLastModifiedDate() async throws {
+        let markdownFileURL = package.contentDirectoryURL.appending(path: "story-with-invalid-lastModified.md")
+        let markdownContent = """
+        ---
+        layout: TestStory
+        lastModified: 2020-03-30 16:37:21
+        ---
+        
+        # Story with invalid lastModified
+        """
+        
+        try markdownContent.write(to: markdownFileURL, atomically: false, encoding: .utf8)
+        
+        try await TestSitePublisher().publish()
+        
+        #expect(package.checkIndexFileExists() == true)
+        
+        try FileManager.default.removeItem(at: markdownFileURL)
+        try FileManager.default.removeItem(at: package.buildDirectoryURL)
+    }
+}
+
+private struct TestPackage {
+    
+    let packageBaseURL: URL
+    let buildDirectoryURL: URL
+    let contentDirectoryURL: URL
+    
+    init() {
+        packageBaseURL = URL(filePath: #filePath, directoryHint: .isDirectory)
+            .deletingLastPathComponent() // "Site.swift"
+            .deletingLastPathComponent() // "Publishing/"
+            .appending(path: "TestWebsitePackage")
+        buildDirectoryURL = packageBaseURL.appending(path: "Build")
+        contentDirectoryURL = packageBaseURL.appending(path: "Content")
+    }
+    
+    func checkIndexFileExists() -> Bool {
+        (try? buildDirectoryURL.appending(path: "index.html").checkPromisedItemIsReachable()) ?? false
+    }
+}

--- a/Tests/IgniteTesting/TestWebsitePackage/Content/Content.txt
+++ b/Tests/IgniteTesting/TestWebsitePackage/Content/Content.txt
@@ -1,0 +1,1 @@
+This place is for generated test Markdown files.

--- a/Tests/IgniteTesting/TestWebsitePackage/Package.swift
+++ b/Tests/IgniteTesting/TestWebsitePackage/Package.swift
@@ -1,0 +1,2 @@
+// Empty Package.swift file to stub source build directory in tests
+// See Publishing/Site.swift

--- a/Tests/IgniteTesting/TestWebsitePackage/Sources/TestSite.swift
+++ b/Tests/IgniteTesting/TestWebsitePackage/Sources/TestSite.swift
@@ -24,6 +24,10 @@ struct TestSite: Site {
         contentCount: 20,
         image: .init(url: "path/to/image.png", width: 100, height: 100)
     )
+    
+    var contentLayouts: [any ContentLayout] = [
+        TestStory()
+    ]
 
     init() {}
 
@@ -32,11 +36,30 @@ struct TestSite: Site {
     }
 }
 
-/// An example page  used in tests.
+/// An example page used in tests.
 struct TestLayout: StaticLayout {
     var title = "Home"
 
     var body: some HTML {
         Text("Hello, World!")
+    }
+}
+
+/// A test publisher for ``TestSite``.
+///
+/// It helps to run `TestSite/publish` with a correct path of the file that triggered the build.
+@MainActor
+struct TestSitePublisher {
+    
+    let site = TestSite()
+    
+    func publish() async throws {
+        try await site.publish()
+    }
+}
+
+struct TestStory: ContentLayout {
+    var body: some HTML {
+        EmptyHTML()
     }
 }


### PR DESCRIPTION
This PR addresses the `"PublishingContext.default accessed before being initialized. Call PublishingContext.initialize() first.` error when Markdown content contains invalid lastModified.

* `Content/parseMetadataDate` is updated to set error on the provided context rather than shared instance of `PublishingContext`