### PR TITLE
Add tests for NavigationBar

### DIFF
--- a/Sources/Ignite/Elements/NavigationBar.swift
+++ b/Sources/Ignite/Elements/NavigationBar.swift
@@ -25,7 +25,7 @@ public struct NavigationBar: BlockHTML {
     }
 
     /// The new number of columns to use.
-    public enum Width {
+    public enum Width: Sendable {
         /// Viewport sets column width
         case viewport
         /// Specific count sets column width

--- a/Tests/IgniteTesting/Elements/NavigationBar.swift
+++ b/Tests/IgniteTesting/Elements/NavigationBar.swift
@@ -12,19 +12,301 @@ import Testing
 /// Tests for the `NavigationBar` element.
 @Suite("Navigation Bar Tests")
 @MainActor struct NavigationBarTests {
-    @Test("Default Column Width Test")
-    func defaultColumnWidth() async throws {
-        let element = NavigationBar().width(.viewport)
-        let output = element.render()
 
-        #expect(output.contains("col container-fluid"))
+    init() throws {
+        try PublishingContext.initialize(for: TestSite(), from: #filePath)
     }
 
-    @Test("Column With Value Test", arguments: [3, 6, 12])
-    func columnWidthValueSet(count: Int) async throws {
-        let element = NavigationBar().width(.count(count))
-        let output = element.render()
+    @Test("Root Tag is Header")
+    func headerTag() async throws {
+        let element = NavigationBar()
 
-        #expect(output.contains("col-md-\(count) container"))
+        #expect(nil != element.render()
+            .htmlTagWithCloseTag("header"))
+    }
+
+    @Test("Has Nav Tag Inside Header")
+    func navTag() async throws {
+        let element = NavigationBar()
+
+        let header = try #require(element.render()
+            .htmlTagWithCloseTag("header"))
+
+        #expect(nil != header.contents.htmlTagWithCloseTag("nav"))
+    }
+
+    @Test("Nav Tag Class Is navbar and navbar-expand-md")
+    func navTagClass() async throws {
+        let element = NavigationBar()
+
+        let navClasses = try #require(element.render()
+            .htmlTagWithCloseTag("header")?.contents
+            .htmlTagWithCloseTag("nav")?.attributes
+            .htmlAttribute(named: "class")?
+            .components(separatedBy: " ")
+        )
+
+        let expected = ["navbar", "navbar-expand-md"]
+        #expect(navClasses == expected)
+    }
+
+    @Test("Nav Tag Class data-bs-theme is blank if style is default")
+    func navTagDefaultTheme() async throws {
+        var element = NavigationBar()
+        element.style = .default
+
+        let navAttributes = try #require(element.render()
+            .htmlTagWithCloseTag("header")?.contents
+            .htmlTagWithCloseTag("nav")?.attributes
+        )
+
+        #expect(nil == navAttributes.htmlAttribute(named: "data-bs-theme"))
+    }
+
+    @Test("Nav Tag Class data-bs-theme is dark if style is dark")
+    func navTagDarkTheme() async throws {
+        var element = NavigationBar()
+        element.style = .dark
+
+        let theme = try #require(element.render()
+            .htmlTagWithCloseTag("header")?.contents
+            .htmlTagWithCloseTag("nav")?.attributes
+            .htmlAttribute(named: "data-bs-theme")
+        )
+
+        let expected = "dark"
+        #expect(theme == expected)
+    }
+
+    @Test("Nav Tag Class data-bs-theme is light if style is light")
+    func navTagLightTheme() async throws {
+        var element = NavigationBar()
+        element.style = .light
+
+        let theme = try #require(element.render()
+            .htmlTagWithCloseTag("header")?.contents
+            .htmlTagWithCloseTag("nav")?.attributes
+            .htmlAttribute(named: "data-bs-theme")
+        )
+
+        let expected = "light"
+        #expect(theme == expected)
+    }
+
+    @Test("Has Div Tag Inside if given width", arguments: [
+        NavigationBar.Width.viewport,
+        .count(2),
+        .count(10)
+    ])
+    func divTagForColumnWidth(width: NavigationBar.Width) async throws {
+        let element = NavigationBar().width(width)
+
+        let navContents = try #require(element.render()
+            .htmlTagWithCloseTag("header")?.contents
+            .htmlTagWithCloseTag("nav")?.contents
+        )
+
+        #expect(nil != navContents.htmlTagWithCloseTag("div"))
+    }
+
+    @Test("Div Tag Class contains column count if given column width", arguments: [0, 3, 7])
+    func divTagClassBeginsWithColumnCount(columns: Int) async throws {
+        let element = NavigationBar().width(.count(columns))
+
+        let divClasses = try #require(element.render()
+            .htmlTagWithCloseTag("header")?.contents
+            .htmlTagWithCloseTag("nav")?.contents
+            .htmlTagWithCloseTag("div")?.attributes
+            .htmlAttribute(named: "class")?
+            .components(separatedBy: " ")
+        )
+
+        let expected = "col-md-\(columns)"
+        #expect(divClasses.contains(expected))
+    }
+
+    @Test("Div Tag Class contains `container` if given column width", arguments: [
+        NavigationBar.Width.count(2),
+        .count(10)
+    ])
+    func divTagClassEndsWithContainer(width: NavigationBar.Width) async throws {
+        let element = NavigationBar().width(width)
+
+        let divClasses = try #require(element.render()
+            .htmlTagWithCloseTag("header")?.contents
+            .htmlTagWithCloseTag("nav")?.contents
+            .htmlTagWithCloseTag("div")?.attributes
+            .htmlAttribute(named: "class")?
+            .components(separatedBy: " ")
+        )
+
+        let expected = "container"
+        #expect(divClasses.contains(expected))
+    }
+
+    @Test("Div Tag Class is as expected if given viewport width")
+    func divTagClassIsFluid() async throws {
+        let element = NavigationBar().width(.viewport)
+
+        let divClasses = try #require(element.render()
+            .htmlTagWithCloseTag("header")?.contents
+            .htmlTagWithCloseTag("nav")?.contents
+            .htmlTagWithCloseTag("div")?.attributes
+            .htmlAttribute(named: "class")?
+            .components(separatedBy: " ")
+        )
+
+        let expected = "col container-fluid".components(separatedBy: " ")
+        #expect(divClasses == expected)
+    }
+
+    @Test("Div Tag contains logo if given logo")
+    func divTagContainsLogo() async throws {
+        let logoImage = Image("")
+        let element = NavigationBar(logo: logoImage)
+
+        let divContents = try #require(element.render()
+            .htmlTagWithCloseTag("header")?.contents
+            .htmlTagWithCloseTag("nav")?.contents
+            .htmlTagWithCloseTag("div")?.contents
+        )
+
+        let expected = try Regex(logoImage.render())
+        #expect(divContents.firstMatch(of: expected) != nil)
+    }
+
+    @Test("Div contains render toggle button if items is not empty")
+    func divTagContainsToggleButton() async throws {
+        let element = NavigationBar(logo: Image("somepath")) {
+            Link("Link 1", target: URL(string: "1")!)
+        }
+
+        let divContents = try #require(element.render()
+            .htmlTagWithCloseTag("header")?.contents
+            .htmlTagWithCloseTag("nav")?.contents
+            .htmlTagWithCloseTag("div")?.contents
+        )
+
+        let expected = """
+<button type="button"\
+ class="btn navbar-toggler"\
+ data-bs-target="#navbarCollapse"\
+ data-bs-toggle="collapse" aria-controls="navbarCollapse"\
+ aria-expanded="false" aria-label="Toggle navigation">\
+<span class="navbar-toggler-icon"></span></button>
+"""
+        #expect(divContents.contains(expected))
+    }
+
+    @Test("Div Tag contains unordered list if items is not nil")
+    func divTagContainsUL() async throws {
+        let item = Link("Link 1", target: URL(string: "1")!)
+        let element = NavigationBar(logo: Image("somepath")) {
+            item
+        }
+
+        let divContents = try #require(element.render()
+            .htmlTagWithCloseTag("header")?.contents
+            .htmlTagWithCloseTag("nav")?.contents
+            .htmlTagWithCloseTag("div")?.contents
+        )
+
+        #expect(nil != divContents.htmlTagWithCloseTag("ul"))
+    }
+
+    @Test("Unordered List omits alignment if default")
+    func ulTagClassDoesNotContainAignmentIfDefault() async throws {
+        let item = Link("Link 1", target: URL(string: "1")!)
+        let element = NavigationBar(logo: Image("somepath")) {
+            item
+        }
+
+        let ulAttributes = try #require(element.render()
+            .htmlTagWithCloseTag("header")?.contents
+            .htmlTagWithCloseTag("nav")?.contents
+            .htmlTagWithCloseTag("div")?.contents
+            .htmlTagWithCloseTag("ul")?.attributes
+        )
+
+        let expected = "justify-content"
+        #expect(!ulAttributes.contains(expected))
+    }
+
+    @Test("Unordered List contains trailing alignment if set")
+    func ulTagClassContainCenterAignmentIfGiven() async throws {
+        let item = Link("Link 1", target: URL(string: "1")!)
+        let element = NavigationBar(logo: Image("somepath")) {
+            item
+        }
+            .navigationItemAlignment(.center)
+
+        let ulClasses = try #require(element.render()
+            .htmlTagWithCloseTag("header")?.contents
+            .htmlTagWithCloseTag("nav")?.contents
+            .htmlTagWithCloseTag("div")?.contents
+            .htmlTagWithCloseTag("ul")?.attributes
+            .htmlAttribute(named: "class")
+        )
+
+        let expected = "justify-content-center"
+        #expect(ulClasses.contains(expected))
+    }
+
+    @Test("Unordered List contains trailing alignment if set")
+    func ulTagClassContainTrailingAignmentIfGiven() async throws {
+        let item = Link("Link 1", target: URL(string: "1")!)
+        let element = NavigationBar(logo: Image("somepath")) {
+            item
+        }
+            .navigationItemAlignment(.trailing)
+
+        let ulClasses = try #require(element.render()
+            .htmlTagWithCloseTag("header")?.contents
+            .htmlTagWithCloseTag("nav")?.contents
+            .htmlTagWithCloseTag("div")?.contents
+            .htmlTagWithCloseTag("ul")?.attributes
+            .htmlAttribute(named: "class")
+        )
+
+        let expected = "justify-content-end"
+        #expect(ulClasses.contains(expected))
+    }
+
+    @Test("UL Tag contains rendered output of item")
+    func divTagContainsRenderedItem() async throws {
+        let item = Link("Link 1", target: URL(string: "1")!)
+        let element = NavigationBar(logo: Image("somepath")) {
+            item
+        }
+
+        let ulContents = try #require(element.render()
+            .htmlTagWithCloseTag("header")?.contents
+            .htmlTagWithCloseTag("nav")?.contents
+            .htmlTagWithCloseTag("div")?.contents
+            .htmlTagWithCloseTag("ul")?.contents
+        )
+
+        let expected = item.render()
+        #expect(ulContents.contains(expected))
+    }
+
+    @Test("UL Tag contains rendered output of items")
+    func divTagContainsRenderedItems() async throws {
+        let item1 = Link("Link 1", target: URL(string: "1")!)
+        let item2 = Link("Link 2", target: URL(string: "2")!)
+        let element = NavigationBar(logo: Image("somepath")) {
+            item1
+            item2
+        }
+
+        let ulContents = try #require(element.render()
+            .htmlTagWithCloseTag("header")?.contents
+            .htmlTagWithCloseTag("nav")?.contents
+            .htmlTagWithCloseTag("div")?.contents
+            .htmlTagWithCloseTag("ul")?.contents
+        )
+
+        #expect(ulContents.contains(item1.render()))
+        #expect(ulContents.contains(item2.render()))
     }
 }

--- a/Tests/IgniteTesting/String-TestingHTML.swift
+++ b/Tests/IgniteTesting/String-TestingHTML.swift
@@ -1,0 +1,42 @@
+//
+// String-TestingHTML.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+
+extension String {
+
+    // no, this isn't appropriate for general HTML parsing,
+    // but for our purposes, testing nested tags,
+    // it should work fine
+    func htmlTagWithCloseTag(_ tagName: String) -> (attributes: String, contents: String)? {
+        // this force try is acceptable because it is known to succeed
+        // if it does fail, then there is something wrong at the call site
+        // (maybe tagName is malformed?)
+        // swiftlint:disable:next force_try
+        let regex = try! Regex("<\(tagName)(.*?)>(.*?)</\(tagName)>")
+
+        guard let unwrapped = firstMatch(of: regex) else {
+            return nil
+        }
+
+        return (attributes: String(unwrapped[1].substring ?? ""),
+                contents: String(unwrapped[2].substring ?? ""))
+    }
+
+    // no, this isn't appropriate for general HTML parsing,
+    // but for our purposes, testing output, it should work fine
+    func htmlAttribute(named name: String) -> String? {
+        // this force try is acceptable because it is known to succeed
+        // if it does fail, then there is something wrong at the call site
+        // (maybe tagName is malformed?)
+        // swiftlint:disable:next force_try
+        let regex = try! Regex("\(name)=\"(.*?)\"")
+
+        guard let found = firstMatch(of: regex)?[1].substring else { return nil }
+        return String(found)
+    }
+}


### PR DESCRIPTION
I added a few methods on String in the test target that make searching for html tags and attributes simpler (in a testing environment only, these obviously aren't robust enough for general work)

Using these methods, I added tests for the structure of the output of NavigationBar as well as for the various parameters that can be applied to NavigationBar.

I had to make one change to NavigationBar.Width, making it Sendable so that it can be parameterized in the tests.

idk, maybe the String extensions should be in a separate PR, but I thought that providing an example of their usefulness would be appropriate. Please advise