### PR TITLE
Fix LengthUnit/isDefault test crash on Xcode 16

### DIFF
--- a/Tests/IgniteTesting/Types/LengthUnit.swift
+++ b/Tests/IgniteTesting/Types/LengthUnit.swift
@@ -93,14 +93,14 @@ struct LengthUnitTests {
 
     @Test("Test default value.")
     func defaultValue() {
-        let element = LengthUnit.default.stringValue
-
+        let element = LengthUnit.default
+        
+        #expect(element == .em(.infinity))
         #expect(element.description == "infem")
     }
 
     @Test("Test is default value.", arguments: [
         (LengthUnit.em(20), false),
-        (LengthUnit.default, true),
         (LengthUnit.percent(Percentage(.infinity)), false),
         (LengthUnit.em(.infinity), true)
     ])


### PR DESCRIPTION
Fix for #451 issue.

This seems to be a bug in Xcode 16. See swift forum discussion for more details https://forums.swift.org/t/fatal-error-internal-inconsistency-no-test-reporter-for-test-case-argumentids/75666.

The test crashes because there are two copies of the same value `LengthUnit.em(.infinity)/LengthUnit.default`. Moved the check of LengthUnit.default into a separate test `LengthUnitTests/defaultValue` to resolve this crash.