### PR TITLE
Eliminate `PublishingError` in favor of simple strings, mirroring `warnings` and ensuring fatal errors crash at the call site.

### DIFF
--- a/Sources/Ignite/Extensions/URL-SelectDirectories.swift
+++ b/Sources/Ignite/Extensions/URL-SelectDirectories.swift
@@ -25,7 +25,7 @@ extension URL {
             }
         }
 
-        throw PublishingError.missingPackageDirectory
+        fatalError(.missingPackageDirectory)
     }
 }
 

--- a/Sources/Ignite/Framework/Site.swift
+++ b/Sources/Ignite/Framework/Site.swift
@@ -264,7 +264,7 @@ public extension Site {
 
         if !context.warnings.isEmpty || !context.errors.isEmpty {
             print("📘 Publish completed with exceptions:")
-            print(context.errors.map { "\t📕 \($0.errorDescription!)" }.joined(separator: "\n"))
+            print(context.errors.map { "\t📕 \($0)" }.joined(separator: "\n"))
             print(context.warnings.map { "\t📙 \($0)" }.joined(separator: "\n"))
         } else {
             print("📗 Publish completed!")

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -56,7 +56,7 @@ final class PublishingContext {
     private(set) var warnings = OrderedSet<String>()
 
     /// Any errors that have been issued during a build.
-    private(set) var errors = [PublishingError]()
+    private(set) var errors = [String]()
 
     /// All the Markdown content this user has inside their Content folder.
     public private(set) var allContent = [Content]()
@@ -133,9 +133,9 @@ final class PublishingContext {
     }
 
     /// Adds an error during a site build.
-    /// - Parameter error: The error to add.
-    func addError(_ error: PublishingError) {
-        errors.append(error)
+    /// - Parameter message: The error to add.
+    func addError(_ message: String) {
+        errors.append(message)
     }
 
     /// Adds one path to the sitemap.
@@ -272,13 +272,13 @@ final class PublishingContext {
         let relativePath = directory.relative(to: buildDirectory)
 
         if siteMap.contains(relativePath) {
-            errors.append(PublishingError.duplicateDirectory(directory))
+            errors.append(.duplicateDirectory(directory))
         }
 
         do {
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         } catch {
-            errors.append(PublishingError.failedToCreateBuildDirectory(directory))
+            errors.append(.failedToCreateBuildDirectory(directory))
         }
 
         let outputURL = directory.appending(path: "index.html")
@@ -292,7 +292,7 @@ final class PublishingContext {
             try html.write(to: outputURL, atomically: true, encoding: .utf8)
             addToSiteMap(relativePath, priority: priority)
         } catch {
-            errors.append(PublishingError.failedToCreateBuildFile(outputURL))
+            errors.append(.failedToCreateBuildFile(outputURL))
         }
     }
 

--- a/Sources/Ignite/Publishing/PublishingError.swift
+++ b/Sources/Ignite/Publishing/PublishingError.swift
@@ -7,127 +7,94 @@
 
 import Foundation
 
-/// Unconditionally prints a given publishing error and stops execution.
-/// - Parameter error: The error to print. The default is an empty string.
-@inline(never)
-func fatalError(_ error: PublishingError) -> Never {
-    fatalError(error.errorDescription ?? "")
-}
-
 /// All the primary errors that can occur when publishing a site. There are other
 /// errors that can be triggered, but they are handled through fatalError() because
 /// something is seriously wrong.
-enum PublishingError: LocalizedError {
+extension String {
     /// Could not find the site's package directory.
-    case missingPackageDirectory
+    static let missingPackageDirectory = "Unable to locate Package.swift."
 
     /// Could not find the app sandbox's home directory
-    case missingSandboxHomeDirectory
-
-    /// Invalid Markdown was found at the specific URL.
-    case badMarkdown(URL)
+    static let missingSandboxHomeDirectory = "Unable to locate App sandbox's home directory"
 
     /// An incorrectly formatted date was found in a piece of Content.
-    case badContentDateFormat
-
-    /// A file cannot be opened (bad encoding, etc).
-    case unopenableFile(String)
-
-    /// Publishing attempted to remove the build directory, but failed.
-    case failedToRemoveBuildDirectory(URL)
-
-    /// Publishing attempted to create the build directory, but failed.
-    case failedToCreateBuildDirectory(URL)
-
-    /// Publishing attempted to create a file during a build, but failed.
-    case failedToCreateBuildFile(URL)
-
-    /// Failed to locate one of the key Ignite resources.
-    case missingSiteResource(String)
-
-    /// Publishing attempted to copy one of the key site resources during a
-    /// build, but failed.
-    case failedToCopySiteResource(String)
-
-    /// A syntax highlighter file resource was not found.
-    case missingSyntaxHighlighter(String)
+    static let badContentDateFormat = "Content dates should be in the format 2024-05-24 15:30."
 
     /// Failed to embed theme-switching JavaScript in `HTMLHead`.
-    case failedToEmbedThemeSwitchingJS
+    static let failedToEmbedThemeSwitchingJS = "Failed to add theme-switching JavaScript to your site's <head>."
 
     /// The site lacks a default theme.
-    case missingDefaultTheme
+    static let missingDefaultTheme = "Ignite requires that you provide either a light or dark theme as the default."
 
     /// The site lacks a default syntax-highlighter theme.
-    case missingDefaultSyntaxHighlighterTheme
+    static let missingDefaultSyntaxHighlighterTheme = "At least one of your themes must specify a syntax highlighter."
 
-    /// A syntax highlighter file resource could not be loaded.
-    case failedToLoadSyntaxHighlighter(String)
-
-    /// Publishing attempted to write out the syntax highlighter data during a
-    /// build, but failed.
-    case failedToWriteSyntaxHighlighters
+    /// Publishing attempted to write out the syntax highlighter data during a build, but failed.
+    static let failedToWriteSyntaxHighlighters = "Failed to write syntax highlighting JavaScript."
 
     /// Publishing attempted to write out the RSS feed during a build, but failed.
-    case failedToWriteFeed
-
-    /// Publishing attempted to write out a file during a build, but failed.
-    case failedToWriteFile(String)
-
-    /// A Markdown file requested a named layout that does not exist.
-    case missingNamedLayout(String)
+    static let failedToWriteFeed = "Failed to generate RSS feed."
 
     /// Site attempted to render Markdown content without a layout in place.
-    case missingDefaultLayout
+    static let missingDefaultLayout = "Your site must provide at least one layout in order to render Markdown."
+
+    /// Invalid Markdown was found at the specific URL.
+    static func badMarkdown(_ url: URL) -> String {
+        "Markdown could not be parsed: \(url.absoluteString)."
+    }
+
+    /// A file cannot be opened (bad encoding, etc).
+    static func unopenableFile(_ reason: String) -> String {
+        "Failed to open file: \(reason)."
+    }
+
+    /// Publishing attempted to remove the build directory, but failed.
+    static func failedToRemoveBuildDirectory(_ url: URL) -> String {
+        "Failed to clear the build folder: \(url.absoluteString)."
+    }
+
+    /// Publishing attempted to create the build directory, but failed.
+    static func failedToCreateBuildDirectory(_ url: URL) -> String {
+        "Failed to create the build folder: \(url.absoluteString)."
+    }
+
+    /// Publishing attempted to create a file during a build, but failed.
+    static func failedToCreateBuildFile(_ url: URL) -> String {
+        "Failed to create the build folder: \(url.absoluteString)."
+    }
+
+    /// Failed to locate one of the key Ignite resources.
+    static func missingSiteResource(_ name: String) -> String {
+        "Failed to locate critical site resource: \(name)."
+    }
+
+    /// Publishing attempted to copy one of the key site resources during a build, but failed.
+    static func failedToCopySiteResource(_ name: String) -> String {
+        "Failed to copy critical site resource to build folder: \(name)."
+    }
+
+    /// A syntax highlighter file resource was not found.
+    static func missingSyntaxHighlighter(_ name: String) -> String {
+        "Failed to locate syntax highlighter JavaScript: \(name)."
+    }
+
+    /// A syntax highlighter file resource could not be loaded.
+    static func failedToLoadSyntaxHighlighter(_ name: String) -> String {
+        "Failed to load syntax highlighter JavaScript: \(name)."
+    }
+
+    /// Publishing attempted to write out a file during a build, but failed.
+    static func failedToWriteFile(_ filename: String) -> String {
+        "Failed to write \(filename) file."
+    }
+
+    /// A Markdown file requested a named layout that does not exist.
+    static func missingNamedLayout(_ name: String) -> String {
+        "Failed to find layout named \(name)."
+    }
 
     /// Publishing attempted to write a file at the specific URL. but it already exists.
-    case duplicateDirectory(URL)
-
-    /// Converts all errors to a string for easier reading.
-    public var errorDescription: String? {
-        switch self {
-        case .missingPackageDirectory:
-            "Unable to locate Package.swift."
-        case .missingSandboxHomeDirectory:
-            "Unable to locate App sandbox's home directory"
-        case .badMarkdown(let url):
-            "Markdown could not be parsed: \(url.absoluteString)."
-        case .badContentDateFormat:
-            "Content dates should be in the format 2024-05-24 15:30."
-        case .unopenableFile(let reason):
-            "Failed to open file: \(reason)."
-        case .failedToRemoveBuildDirectory(let url):
-            "Failed to clear the build folder: \(url.absoluteString)."
-        case .failedToCreateBuildDirectory(let url):
-            "Failed to create the build folder: \(url.absoluteString)."
-        case .failedToCreateBuildFile(let url):
-            "Failed to create the build folder: \(url.absoluteString)."
-        case .missingSiteResource(let name):
-            "Failed to locate critical site resource: \(name)."
-        case .failedToCopySiteResource(let name):
-            "Failed to copy critical site resource to build folder: \(name)."
-        case .missingSyntaxHighlighter(let name):
-            "Failed to locate syntax highlighter JavaScript: \(name)."
-        case .failedToEmbedThemeSwitchingJS:
-            "Failed to add theme-switching JavaScript to your site's <head>."
-        case .missingDefaultTheme:
-            "Ignite requires that you provide either a light or dark theme as the default."
-        case .missingDefaultSyntaxHighlighterTheme:
-            "At least one of your themes must specify a syntax highlighter."
-        case .failedToLoadSyntaxHighlighter(let name):
-            "Failed to load syntax highlighter JavaScript: \(name)."
-        case .failedToWriteSyntaxHighlighters:
-            "Failed to write syntax highlighting JavaScript."
-        case .failedToWriteFeed:
-            "Failed to generate RSS feed."
-        case .failedToWriteFile(let filename):
-            "Failed to write \(filename) file."
-        case .missingNamedLayout(let name):
-            "Failed to find layout named \(name)."
-        case .missingDefaultLayout:
-            "Your site must provide at least one layout in order to render Markdown."
-        case .duplicateDirectory(let url):
-            "Duplicate URL found: \(url). This is a fatal error."
-        }
+    static func duplicateDirectory(_ url: URL) -> String {
+        "Duplicate URL found: \(url). This is a fatal error."
     }
 }

--- a/Sources/Ignite/Rendering/Markdown/MarkdownToHTML.swift
+++ b/Sources/Ignite/Rendering/Markdown/MarkdownToHTML.swift
@@ -50,7 +50,7 @@ public struct MarkdownToHTML: MarkdownRenderer, MarkupVisitor {
         do {
             markdown = try String(contentsOf: url)
         } catch {
-            throw PublishingError.unopenableFile(error.localizedDescription)
+            fatalError(.unopenableFile(error.localizedDescription))
         }
 
         let processed = processMetadata(for: markdown)


### PR DESCRIPTION
An improvement on our working error-handling system until we officially tackle the subject.