### PR TITLE
Add initializer to `Section` that takes a header argument and wraps its children in a `<section>` instead of a `<div>`.

### DIFF
--- a/Sources/Ignite/Elements/Section.swift
+++ b/Sources/Ignite/Elements/Section.swift
@@ -5,14 +5,13 @@
 // See LICENSE for license information.
 //
 
-/// A container element that wraps its children in a `div` element.
+/// A container element that groups its children together.
 ///
-/// Use `Section` when you want to group elements together and have them rendered
-/// within a containing HTML `div`. This is useful for applying shared styling,
-/// creating layout structures, or logically grouping related content.
+/// When initialized with just content, the section wraps its children in a `<div>`.
+/// When initialized with a header and content, the section wraps its children in a `<section>`.
 ///
 /// - Note: Unlike ``Group``, modifiers applied to a `Section` affect the
-///         containing `div` element rather than being propagated to child elements.
+///         containing element rather than being propagated to child elements.
 public struct Section: BlockHTML {
     /// The content and behavior of this HTML.
     public var body: some HTML { self }
@@ -26,24 +25,50 @@ public struct Section: BlockHTML {
     /// How many columns this should occupy when placed in a grid.
     public var columnWidth = ColumnWidth.automatic
 
+    /// The heading text of the section.
+    var header: String?
+
+    /// The heading's semantic font size.
+    var headerStyle: Font.Style = .title2
+
     var items: [any HTML] = []
 
+    init(_ items: any HTML) {
+        self.items = flatUnwrap(items)
+    }
+
+    /// Creates a section that renders as a `div` element.
+    /// - Parameter content: The content to display within this section.
     public init(@HTMLBuilder content: () -> some HTML) {
         self.items = flatUnwrap(content())
+        self.tag("div")
     }
 
-    public init(_ items: any HTML) {
-        self.items = flatUnwrap(items)
+    /// Creates a section that renders as a `section` element with a heading.
+    /// - Parameters:
+    ///   - header: The text to display as the section's heading
+    ///   - content: The content to display within this section
+    public init(_ header: String, @HTMLBuilder content: () -> some HTML) {
+        self.items = flatUnwrap(content())
+        self.header = header
+        self.tag("section")
     }
 
-    init(items: [any HTML]) {
-        self.items = flatUnwrap(items)
+    /// Adjusts the semantic importance of the section's header by changing its font style.
+    /// - Parameter fontStyle: The font style to apply to the header
+    /// - Returns: A section with the modified header style
+    public func headerProminence(_ fontStyle: Font.Style) -> Self {
+        var copy = self
+        copy.headerStyle = fontStyle
+        return copy
     }
 
     public func render() -> String {
+        var items = items
+        if let header = header {
+            items.insert(Text(header).fontStyle(headerStyle), at: 0)
+        }
         let content = items.map { $0.render() }.joined()
-        var attributes = attributes
-        attributes.tag = "div"
         return attributes.description(wrapping: content)
     }
 }

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -351,7 +351,7 @@ final class PublishingContext {
         layout.environment = values
 
         let body = ContentContext.withCurrentContent(content) {
-            Section(items: [layout.body])
+            Section(layout.body)
         }
 
         currentRenderingPath = content.path

--- a/Tests/IgniteTesting/Elements/Section.swift
+++ b/Tests/IgniteTesting/Elements/Section.swift
@@ -15,15 +15,33 @@ import Testing
 @MainActor
 
 struct SectionTests {
-    @Test("init With Content Test")
-    func initWithContent() async throws {
+    @Test("Section")
+    func section() async throws {
         let element = Section {
             Span("Hello, World!")
             Span("Goodbye, World!")
         }
-        let output = element.render()
 
+        let output = element.render()
         #expect(output == "<div><span>Hello, World!</span><span>Goodbye, World!</span></div>")
     }
 
+    @Test("Section with Header")
+    func sectionWithHeader() async throws {
+        let element = Section("Greetings") {
+            Span("Hello, World!")
+            Span("Goodbye, World!")
+        }
+        .headerProminence(.title3)
+
+        let output = element.render()
+
+        #expect(output == """
+        <section>\
+        <h3>Greetings</h3>\
+        <span>Hello, World!</span>\
+        <span>Goodbye, World!</span>\
+        </section>
+        """)
+    }
 }


### PR DESCRIPTION
It's likely that some users might expect Ignite's `Section` element to wrap its children in a `<section>`, not a `<div>`. This PR empowers `Section` to do just that depending on context (the initializer used).