### PR TITLE
moved the test of MetaLink.highlighterThemeMetaLinks() to its own Test Suite

### DIFF
--- a/Sources/Ignite/Framework/Language.swift
+++ b/Sources/Ignite/Framework/Language.swift
@@ -278,3 +278,5 @@ public enum Language: String, Sendable {
     case zulu = "zu"
 }
 // swiftlint:enable type_body_length
+
+extension Language: CaseIterable {}

--- a/Tests/IgniteTesting/Elements/HTMLDocument.swift
+++ b/Tests/IgniteTesting/Elements/HTMLDocument.swift
@@ -14,8 +14,83 @@ import Testing
 @Suite("HTMLDocument Tests")
 @MainActor
 struct HTMLDocumentTests {
-    @Test("ExampleTest")
-    func example() async throws {
+    
+    init() throws {
+        try PublishingContext.initialize(for: TestSite(), from: #filePath)
+    }
 
+    @Test("Starts with doctype html")
+    func containsHTMLDoctype() {
+        let sut = HTMLDocument {}
+        let output = sut.render()
+        
+        #expect(output.hasPrefix("<!doctype html>"))
+    }
+    
+    @Test("Contains html tag")
+    func containsHTMLTag() {
+        let sut = HTMLDocument {}
+        let output = sut.render()
+        
+        #expect(nil != output.htmlTagWithCloseTag("html"))
+    }
+
+    @Test("theme attribute is `auto`")
+    func theme_is_auto() throws {
+        let sut = HTMLDocument {}
+        let output = sut.render()
+        
+        let theme = try #require(output.htmlTagWithCloseTag("html")?.attributes
+            .htmlAttribute(named: "data-bs-theme")
+        )
+        
+        #expect(theme == "auto")
+    }
+
+    @Test("lang attribute defaults to en")
+    func language_attribute_defaults_to_en() throws {
+        let sut = HTMLDocument {}
+        let output = sut.render()
+        
+        let language = try #require(output.htmlTagWithCloseTag("html")?.attributes
+            .htmlAttribute(named: "lang")
+        )
+        
+        #expect(language == "en")
+    }
+
+    @Test("lang attribute is taken from language property", arguments: Language.allCases)
+    func language_property_determines_lang_attribute(_ language: Language) throws {
+        let sut = HTMLDocument(language: language) {}
+        let output = sut.render()
+        
+        let langAttribute = try #require(output.htmlTagWithCloseTag("html")?.attributes
+            .htmlAttribute(named: "lang")
+        )
+        
+        #expect(langAttribute == language.rawValue)
+    }
+
+    @Test("If contents are empty then html tag is empty")
+    func contents_are_empty_by_default() throws {
+        let sut = HTMLDocument {}
+        let output = sut.render()
+
+        let htmlContents = try #require(output.htmlTagWithCloseTag("html")?.contents)
+        
+        #expect(htmlContents.isEmpty)
+    }
+    
+    @Test("places output of contents into contents of html tag")
+    func html_tag_contents_are_taken_from_contents_property() async throws {
+        
+        let body = HTMLBody { "Hello World" }
+        let sut = HTMLDocument { body }
+
+        let expected = body.render()
+        
+        let htmlContents = try #require(sut.render().htmlTagWithCloseTag("html")?.contents)
+
+        #expect(htmlContents == expected)
     }
 }

--- a/Tests/IgniteTesting/Elements/HTMLHead.swift
+++ b/Tests/IgniteTesting/Elements/HTMLHead.swift
@@ -13,22 +13,4 @@ import Testing
 /// Tests for the `HTMLHead` element.
 @Suite("HTMLHead Tests")
 @MainActor
-struct HTMLHeadTests {
-    init() throws {
-        try PublishingContext.initialize(for: TestSite(), from: #filePath)
-    }
-
-    @Test("Highlighting meta tags are sorted")
-    func highlighterThemesAreSorted() async throws {
-        let links = MetaLink.highlighterThemeMetaLinks(for: [.xcodeDark, .githubDark, .twilight])
-        let output = links.map { $0.render() }
-
-        #expect(
-            output == [
-                "<link href=\"/css/prism-github-dark.css\" rel=\"stylesheet\" data-highlight-theme=\"github-dark\" />",
-                "<link href=\"/css/prism-twilight.css\" rel=\"stylesheet\" data-highlight-theme=\"twilight\" />",
-                "<link href=\"/css/prism-xcode-dark.css\" rel=\"stylesheet\" data-highlight-theme=\"xcode-dark\" />"
-            ]
-        )
-    }
-}
+struct HTMLHeadTests {}

--- a/Tests/IgniteTesting/Elements/MetaLink.swift
+++ b/Tests/IgniteTesting/Elements/MetaLink.swift
@@ -48,3 +48,25 @@ struct MetaLinkTests {
         #expect(output == "<link href=\"https://www.example.com\" rel=\"alternate\" />")
     }
 }
+
+@Suite("MetaLink.highlighterThemeMetaLinks Tests")
+@MainActor
+struct highlighterThemeMetaLinksTests {
+    init() throws {
+        try PublishingContext.initialize(for: TestSite(), from: #filePath)
+    }
+
+    @Test("Highlighting meta tags are sorted")
+    func highlighterThemesAreSorted() async throws {
+        let links = MetaLink.highlighterThemeMetaLinks(for: [.xcodeDark, .githubDark, .twilight])
+        let output = links.map { $0.render() }
+
+        #expect(
+            output == [
+                "<link href=\"/css/prism-github-dark.css\" rel=\"stylesheet\" data-highlight-theme=\"github-dark\" />",
+                "<link href=\"/css/prism-twilight.css\" rel=\"stylesheet\" data-highlight-theme=\"twilight\" />",
+                "<link href=\"/css/prism-xcode-dark.css\" rel=\"stylesheet\" data-highlight-theme=\"xcode-dark\" />"
+            ]
+        )
+    }
+}


### PR DESCRIPTION
This one test that was in Testing/IgniteTests/Eleemnts/HTMLHead.swift tests a method on MetaLink, not a method on HTMLHead.  While the output DOES appear in HTMLHead, it probably should be in the same module as other tests on MetaLinks.