### PR TITLE
moved test to appropriate module

### DIFF
--- a/Tests/IgniteTesting/Elements/HTMLHead.swift
+++ b/Tests/IgniteTesting/Elements/HTMLHead.swift
@@ -13,22 +13,4 @@ import Testing
 /// Tests for the `HTMLHead` element.
 @Suite("HTMLHead Tests")
 @MainActor
-struct HTMLHeadTests {
-    init() throws {
-        try PublishingContext.initialize(for: TestSite(), from: #filePath)
-    }
-
-    @Test("Highlighting meta tags are sorted")
-    func highlighterThemesAreSorted() async throws {
-        let links = MetaLink.highlighterThemeMetaLinks(for: [.xcodeDark, .githubDark, .twilight])
-        let output = links.map { $0.render() }
-
-        #expect(
-            output == [
-                "<link href=\"/css/prism-github-dark.css\" rel=\"stylesheet\" data-highlight-theme=\"github-dark\" />",
-                "<link href=\"/css/prism-twilight.css\" rel=\"stylesheet\" data-highlight-theme=\"twilight\" />",
-                "<link href=\"/css/prism-xcode-dark.css\" rel=\"stylesheet\" data-highlight-theme=\"xcode-dark\" />"
-            ]
-        )
-    }
-}
+struct HTMLHeadTests {}

--- a/Tests/IgniteTesting/Elements/MetaLink.swift
+++ b/Tests/IgniteTesting/Elements/MetaLink.swift
@@ -14,6 +14,11 @@ import Testing
 @Suite("MetaLink Tests")
 @MainActor
 struct MetaLinkTests {
+
+    init() throws {
+        try PublishingContext.initialize(for: TestSite(), from: #filePath)
+    }
+
     @Test("href string and rel string")
     func hrefStringAndRelString() async throws {
         let element = MetaLink(href: "https://www.example.com", rel: "canonical")
@@ -46,14 +51,6 @@ struct MetaLinkTests {
         let output = element.render()
 
         #expect(output == "<link href=\"https://www.example.com\" rel=\"alternate\" />")
-    }
-}
-
-@Suite("MetaLink.highlighterThemeMetaLinks Tests")
-@MainActor
-struct MetaLink_highlighterThemeMetaLinksTests {
-    init() throws {
-        try PublishingContext.initialize(for: TestSite(), from: #filePath)
     }
 
     @Test("Highlighting meta tags are sorted")

--- a/Tests/IgniteTesting/Elements/MetaLink.swift
+++ b/Tests/IgniteTesting/Elements/MetaLink.swift
@@ -51,7 +51,7 @@ struct MetaLinkTests {
 
 @Suite("MetaLink.highlighterThemeMetaLinks Tests")
 @MainActor
-struct highlighterThemeMetaLinksTests {
+struct MetaLink_highlighterThemeMetaLinksTests {
     init() throws {
         try PublishingContext.initialize(for: TestSite(), from: #filePath)
     }

--- a/Tests/IgniteTesting/Elements/MetaLink.swift
+++ b/Tests/IgniteTesting/Elements/MetaLink.swift
@@ -48,3 +48,25 @@ struct MetaLinkTests {
         #expect(output == "<link href=\"https://www.example.com\" rel=\"alternate\" />")
     }
 }
+
+@Suite("MetaLink.highlighterThemeMetaLinks Tests")
+@MainActor
+struct highlighterThemeMetaLinksTests {
+    init() throws {
+        try PublishingContext.initialize(for: TestSite(), from: #filePath)
+    }
+
+    @Test("Highlighting meta tags are sorted")
+    func highlighterThemesAreSorted() async throws {
+        let links = MetaLink.highlighterThemeMetaLinks(for: [.xcodeDark, .githubDark, .twilight])
+        let output = links.map { $0.render() }
+
+        #expect(
+            output == [
+                "<link href=\"/css/prism-github-dark.css\" rel=\"stylesheet\" data-highlight-theme=\"github-dark\" />",
+                "<link href=\"/css/prism-twilight.css\" rel=\"stylesheet\" data-highlight-theme=\"twilight\" />",
+                "<link href=\"/css/prism-xcode-dark.css\" rel=\"stylesheet\" data-highlight-theme=\"xcode-dark\" />"
+            ]
+        )
+    }
+}

--- a/Tests/IgniteTesting/Modifiers/AspectRatio.swift
+++ b/Tests/IgniteTesting/Modifiers/AspectRatio.swift
@@ -46,6 +46,7 @@ struct AspectRatioTests {
 
     @Test("Verify Aspect Ratios with Content Modes")
     func verifyAspectRatiosWithContentModes() async throws {
+        // swiftlint:disable:next large_tuple
         let testCases: [(AspectRatio, ContentMode, String)] = [
             (.square, .fit, "<div class=\"ratio ratio-1x1\"><i class=\"bi-swift object-fit-contain\"></i></div>"),
             (.r4x3, .fill, "<div class=\"ratio ratio-4x3\"><i class=\"bi-swift object-fit-cover\"></i></div>")


### PR DESCRIPTION
This one test that was in Testing/IgniteTests/Eleemnts/HTMLHead.swift tests a method on MetaLink, not a method on HTMLHead. While the output DOES appear in HTMLHead, it probably should be in the same module as other tests on MetaLinks.