### PR TITLE
Tests for hidden modifier

### DIFF
--- a/Tests/IgniteTesting/Modifiers/Hidden.swift
+++ b/Tests/IgniteTesting/Modifiers/Hidden.swift
@@ -14,8 +14,36 @@ import Testing
 @Suite("Hidden Tests")
 @MainActor
 struct HiddenTests {
-    @Test("ExampleTest")
-    func example() async throws {
+    @Test("Hidden Modifier for Text")
+    func hiddenForText() async throws {
+        let element = Text("Hello world!").hidden()
+        let output = element.render()
+        #expect(
+            output == "<p class=\"d-none\">Hello world!</p>"
+        )
+    }
 
+    @Test("MediaQuery based hidden Modifier for Text")
+    func hiddenMediaQueryForText() async throws {
+        CSSManager.default.setThemes([AutoTheme()])
+        let mediaQuery = MediaQuery.orientation(.landscape)
+        let element = Text("Hello world!").hidden(mediaQuery)
+        let output = element.render()
+        let className = CSSManager.default.className(for: [mediaQuery])
+        #expect(
+            output == "<p class=\"\(className)\">Hello world!</p>"
+        )
+    }
+
+    @Test("Hidden Modifier for Column")
+    func hiddenForColumn() async throws {
+        let element = Column {
+            Label(text: "Left Label")
+            Label(text: "Right Label")
+        }.hidden()
+        let output = element.render()
+        #expect(
+            output == "<td colspan=\"1\" class=\"d-none\"><label>Left Label</label><label>Right Label</label></td>"
+        )
     }
 }


### PR DESCRIPTION
In hiddenMediaQueryForText() test, I had to set a theme on CSSManager for the className(for:) call to return the class name instead of an empty string.
That is because, in CSSManager, the register MediaQuery (called by the HiddenModifier initialiser) creates a pending registration in case there is no theme.

I could write the test using hashForQueries() instead of className(for:) but:
- I'm now leaking implementation details in my test
- what would happen when generating a site if no theme is set (sorry, I don't know Ignite enough - haven't taken the time to create a test site)
