### PR TITLE
RFC822 is in english only - use POSIX

### DIFF
--- a/Sources/Ignite/Extensions/Date-RFC822.swift
+++ b/Sources/Ignite/Extensions/Date-RFC822.swift
@@ -11,6 +11,7 @@ extension Date {
     /// Converts `Date` objects to RFC-822 format, which is used by RSS.
     public func asRFC822(timeZone: TimeZone? = nil) -> String {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"
         if let timeZone { formatter.timeZone = timeZone }
         return formatter.string(from: self)


### PR DESCRIPTION
While running the Ignite test suite I came across the following (and many more) errors:

```
􀢄  Test "Test Against Known Output for Asia/Jakarta Time" recorded an issue with 1 argument instance → Instance(input: 2261-07-11 17:55:33 +0000, expected: "Fri, 12 Jul 2261 00:55:33 +0700") at Date-RFC822.swift:105:9: Expectation failed: (instance.input.asRFC822(timeZone: timezone) → "Fr., 12 Juli 2261 00:55:33 +0700") == (instance.expected → "Fri, 12 Jul 2261 00:55:33 +0700")
􀢄  Test "Test Against Known Output for Asia/Jakarta Time" recorded an issue with 1 argument instance → Instance(input: 3747-01-03 20:53:19 +0000, expected: "Wed, 04 Jan 3747 03:53:19 +0700") at Date-RFC822.swift:105:9: Expectation failed: (instance.input.asRFC822(timeZone: timezone) → "Mi., 04 Jan. 3747 03:53:19 +0700") == (instance.expected → "Wed, 04 Jan 3747 03:53:19 +0700")
􀢄  Test "Test Against Known Output for Asia/Jakarta Time" recorded an issue with 1 argument instance → Instance(input: 3671-11-20 14:31:51 +0000, expected: "Fri, 20 Nov 3671 21:31:51 +0700") at Date-RFC822.swift:105:9: Expectation failed: (instance.input.asRFC822(timeZone: timezone) → "Fr., 20 Nov. 3671 21:31:51 +0700") == (instance.expected → "Fri, 20 Nov 3671 21:31:51 +0700")
􀢄  Test "Test Against Known Output for Asia/Jakarta Time" recorded an issue with 1 argument instance → Instance(input: 2061-06-29 07:56:21 +0000, expected: "Wed, 29 Jun 2061 14:56:21 +0700") at Date-RFC822.swift:105:9: Expectation failed: (instance.input.asRFC822(timeZone: timezone) → "Mi., 29 Juni 2061 14:56:21 +0700") == (instance.expected → "Wed, 29 Jun 2061 14:56:21 +0700")
􀢄  Test "Test Against Known Output for Asia/Jakarta Time" recorded an issue with 1 argument instance → Instance(input: 2059-04-29 07:08:04 +0000, expected: "Tue, 29 Apr 2059 14:08:04 +0700") at Date-RFC822.swift:105:9: Expectation failed: (instance.input.asRFC822(timeZone: timezone) → "Di., 29 Apr. 2059 14:08:04 +0700") == (instance.expected → "Tue, 29 Apr 2059 14:08:04 +0700")
􀢄  Test "Test Against Known Output for Asia/Jakarta Time" recorded an issue with 1 argument instance → Instance(input: 2938-11-01 04:59:34 +0000, expected: "Sat, 01 Nov 2938 11:59:34 +0700") at Date-RFC822.swift:105:9: Expectation failed: (instance.input.asRFC822(timeZone: timezone) → "Sa., 01 Nov. 2938 11:59:34 +0700") == (instance.expected → "Sat, 01 Nov 2938 11:59:34 +0700")
􀢄  Test "Test Against Known Output for Asia/Jakarta Time" recorded an issue with 1 argument instance → Instance(input: 2469-07-27 10:40:45 +0000, expected: "Sat, 27 Jul 2469 17:40:45 +0700") at Date-RFC822.swift:105:9: Expectation failed: (instance.input.asRFC822(timeZone: timezone) → "Sa., 27 Juli 2469 17:40:45 +0700") == (instance.expected → "Sat, 27 Jul 2469 17:40:45 +0700")
􀢄  Test "Test Against Known Output for America/St Johns Time" recorded an issue with 1 argument instance → Instance(input: 2604-03-02 09:10:18 +0000, expected: "Fri, 02 Mar 2604 05:40:18 -0330") at Date-RFC822.swift:84:9: Expectation failed: (instance.input.asRFC822(timeZone: timezone) → "Fr., 02 März 2604 05:40:18 -0330") == (instance.expected → "Fri, 02 Mar 2604 05:40:18 -0330")
􀢄  Test "Test Against Known Output for Asia/Jakarta Time" recorded an issue with 1 argument instance → Instance(input: 2604-03-02 09:10:18 +0000, expected: "Fri, 02 Mar 2604 16:10:18 +0700") at Date-RFC822.swift:105:9: Expectation failed: (instance.input.asRFC822(timeZone: timezone) → "Fr., 02 März 2604 16:10:18 +0700") == (instance.expected → "Fri, 02 Mar 2604 16:10:18 +0700")
􀢄  Test "Test Against Known Output for America/St Johns Time" recorded an issue with 1 argument instance → Instance(input: 3884-01-19 10:45:37 +0000, expected: "Sat, 19 Jan 3884 07:15:37 -0330") at Date-RFC822.swift:84:9: Expectation failed: (instance.input.asRFC822(timeZone: timezone) → "Sa., 19 Jan. 3884 07:15:37 -0330") == (instance.expected → "Sat, 19 Jan 3884 07:15:37 -0330")
```

As you can see my macOS has a different locale than what is expected by the tests implemented in DateRFC822Tests.swift.
After investigating and looking at the RFC822 standard, I came across the solution implemented in this PR: hardcode the Locale to "en_US_POSIX".

I'm not sure whether this is the right approach to fix it, but as I understand, we currently do not have a Locale support. We do have an optional `language` implemented in the `Site` protocol, which would allow derivation of a locale. But how would this be passed down to `Date.asRFC822()` and would it be correct to adapt to the sites language?
