### PR TITLE
Fix main actor isolation errors when building as Xcode target

### DIFF
--- a/Sources/Ignite/Elements/EmptyHTML.swift
+++ b/Sources/Ignite/Elements/EmptyHTML.swift
@@ -9,7 +9,7 @@
 /// Used as a default or fallback when no content is needed
 public struct EmptyHTML: HTML, InlineElement, RootElement {
     /// Creates a new empty HTML element
-    public init() {}
+    public nonisolated init() {}
 
     /// Returns self as the body content since this is an empty element
     public var body: some HTML { self }

--- a/Sources/Ignite/Framework/ElementTypes/BlockHTML.swift
+++ b/Sources/Ignite/Framework/ElementTypes/BlockHTML.swift
@@ -7,6 +7,7 @@
 
 /// Describes a HTML element that is rendered in block style, i.e. that it occupies the
 /// full width of the page by default.
+@MainActor
 public protocol BlockHTML: HTML, HorizontalAligning {
     /// How many columns this should occupy when placed in a grid.
     var columnWidth: ColumnWidth { get set }

--- a/Sources/Ignite/Framework/ElementTypes/InlineElement.swift
+++ b/Sources/Ignite/Framework/ElementTypes/InlineElement.swift
@@ -7,4 +7,5 @@
 
 /// An element that exists inside a block element, such as an emphasized
 /// piece of text.
+@MainActor
 public protocol InlineElement: HTML {}

--- a/Sources/Ignite/Framework/ElementTypes/RootElement.swift
+++ b/Sources/Ignite/Framework/ElementTypes/RootElement.swift
@@ -6,4 +6,5 @@
 //
 
 /// Describes elements that can exist directly inside a HTML container.
+@MainActor
 public protocol RootElement: HTML {}

--- a/Sources/Ignite/Framework/Layoutable.swift
+++ b/Sources/Ignite/Framework/Layoutable.swift
@@ -6,6 +6,7 @@
 //
 
 /// A protocol that allows pages of any type to use a layout.
+@MainActor
 public protocol Layoutable: Sendable {
     /// The type of layout you want this page to use.
     associatedtype LayoutType: Layout

--- a/Sources/Ignite/Modifiers/HorizontalAlignment.swift
+++ b/Sources/Ignite/Modifiers/HorizontalAlignment.swift
@@ -46,6 +46,7 @@ extension HorizontalAlignment: Responsive {
 }
 
 /// Determines which elements can have horizontal alignment attached,
+@MainActor
 public protocol HorizontalAligning: HTML { }
 
 /// A modifier that controls horizontal alignment of HTML elements


### PR DESCRIPTION
## Summary

- Resolves #499

This PR contains changes that resolves the issues when building Ignite as Xcode target. For example, when Ignite is integrated as a dependency using [Tuist](https://github.com/tuist/tuist).

## What was done

- [x] Annotate the following protocols with `@MainActor`: `BlockHTML`, `InlineElement`, `RootElement`, `Layoutable`, and `HorizontalAligning`.
- [x] Annotate `EmptyHTML.init` with `nonisolated`.

## Additional info

Although the changes included in this PR solves the problem described in the issue, more changes may be required to improve actor-isolation issues. This PR contains minimal amount of changes to the source code that allows to compile Ignite when integrating it using Tuist.
