### PR TITLE
Consolidate RSS-feed-related environment variables.

### DIFF
--- a/Sources/Ignite/Components/FeedLink.swift
+++ b/Sources/Ignite/Components/FeedLink.swift
@@ -12,16 +12,18 @@ public struct FeedLink: HTML {
     @Environment(\.feedConfiguration) private var feedConfig
 
     public var body: some HTML {
-        Text {
-            if builtInIconsEnabled != .none {
-                Image(systemName: "rss-fill")
-                    .foregroundStyle("#f26522")
-                    .margin(.trailing, .px(10))
-            }
+        if let feedConfig {
+            Text {
+                if builtInIconsEnabled != .none {
+                    Image(systemName: "rss-fill")
+                        .foregroundStyle("#f26522")
+                        .margin(.trailing, .px(10))
+                }
 
-            Link("RSS Feed", target: feedConfig.path)
-            EmptyHTML()
+                Link("RSS Feed", target: feedConfig.path)
+                EmptyHTML()
+            }
+            .horizontalAlignment(.center)
         }
-        .horizontalAlignment(.center)
     }
 }

--- a/Sources/Ignite/Framework/Environment/EnvironmentValues.swift
+++ b/Sources/Ignite/Framework/Environment/EnvironmentValues.swift
@@ -24,10 +24,7 @@ public struct EnvironmentValues {
     public var content: ContentLoader
 
     /// Configuration for RSS/Atom feed generation.
-    public var feedConfiguration: FeedConfiguration
-
-    /// Whether feed generation is enabled for the site.
-    public var isFeedEnabled: Bool
+    public var feedConfiguration: FeedConfiguration?
 
     /// Available themes for the site, including light, dark, and any alternates.
     public var themes: [any Theme] = []
@@ -65,7 +62,6 @@ public struct EnvironmentValues {
     public init() {
         self.content = ContentLoader(content: [])
         self.feedConfiguration = FeedConfiguration(mode: .full, contentCount: 0)
-        self.isFeedEnabled = false
         self.themes = []
         self.decode = .init(sourceDirectory: URL(filePath: ""))
         self.author = ""
@@ -83,7 +79,6 @@ public struct EnvironmentValues {
         self.decode = DecodeAction(sourceDirectory: sourceDirectory)
         self.content = ContentLoader(content: allContent)
         self.feedConfiguration = site.feedConfiguration
-        self.isFeedEnabled = site.isFeedEnabled
         self.themes = site.allThemes
         self.author = site.author
         self.siteName = site.name

--- a/Sources/Ignite/Framework/FeedConfiguration.swift
+++ b/Sources/Ignite/Framework/FeedConfiguration.swift
@@ -9,9 +9,6 @@
 public struct FeedConfiguration: Sendable {
     /// How much content should be provided in this feed.
     public enum ContentMode: Sendable {
-        /// Disable the feed entirely.
-        case disabled
-
         /// Provide only the description of each piece of content.
         case descriptionOnly
 
@@ -50,7 +47,7 @@ public struct FeedConfiguration: Sendable {
     /// How much content should be provided in this feed.
     var mode: ContentMode
 
-    /// How many items of contentshould be returned.
+    /// How many items of content should be returned.
     var contentCount: Int
 
     /// The path to where the generated rss xml file for the feed endpoint should be.
@@ -65,13 +62,14 @@ public struct FeedConfiguration: Sendable {
 
     /// Creates a custom feed configuration from the options provided.
     /// - Parameters:
-    ///   - mode: Whether to descriptions or full article text, or to disable the
-    ///   feed entirely.
+    ///   - mode: Whether to descriptions or full article text.
     ///   - contentCount: How many pieces of content to return.
+    ///   Initializer returns `nil` if less than or equal to `0`.
     ///   - path: The path where the RSS feed should be accessible, default to /feed.rss
     ///   - image: An optional image used to customize your feed's
     ///   appearance in feed readers.
-    public init(mode: ContentMode, contentCount: Int, path: String = "/feed.rss", image: FeedImage? = nil) {
+    public init?(mode: ContentMode, contentCount: Int, path: String = "/feed.rss", image: FeedImage? = nil) {
+        guard contentCount > 0 else { return nil }
         self.mode = mode
         self.contentCount = contentCount
         self.path = path

--- a/Sources/Ignite/Framework/Site.swift
+++ b/Sources/Ignite/Framework/Site.swift
@@ -91,8 +91,9 @@ public protocol Site: Sendable {
     var markdownRenderer: MarkdownRendererType.Type { get }
 
     /// Controls how the RSS feed for your site should be generated. The default
-    /// configuration sends back content description only for 20 items.
-    var feedConfiguration: FeedConfiguration { get }
+    /// configuration sends back content description only for 20 items. To disable
+    /// your site's RSS feed, set this property to `nil`.
+    var feedConfiguration: FeedConfiguration? { get }
 
     /// Controls how search engines and similar index your site. The default
     /// configuration allows all robots to index everything.
@@ -189,13 +190,7 @@ public extension Site {
 
     /// A default feed configuration allows 20 items of content, showing just
     /// their descriptions.
-    var feedConfiguration: FeedConfiguration { .default }
-
-    /// A simple helper property that determines whether we have a feed
-    /// configuration that means a feed should actually be made.
-    var isFeedEnabled: Bool {
-        feedConfiguration.mode != .disabled && feedConfiguration.contentCount > 0
-    }
+    var feedConfiguration: FeedConfiguration? { .default }
 
     /// A default robots.txt configuration that allows all robots to index all pages.
     var robotsConfiguration: DefaultRobotsConfiguration { DefaultRobotsConfiguration() }

--- a/Sources/Ignite/Publishing/FeedGenerator.swift
+++ b/Sources/Ignite/Publishing/FeedGenerator.swift
@@ -7,14 +7,21 @@
 
 @MainActor
 struct FeedGenerator {
+    var feedConfig: FeedConfiguration
     var site: any Site
     var content: [Content]
+
+    init(config: FeedConfiguration, site: any Site, content: [Content]) {
+        self.feedConfig = config
+        self.site = site
+        self.content = content
+    }
 
     func generateFeed() -> String {
         let contentXML = generateContentXML()
         var result = generateRSSHeader()
 
-        if let image = site.feedConfiguration.image {
+        if let image = feedConfig.image {
             result += """
             <image>\
             <url>\(image.url)</url>\
@@ -37,16 +44,16 @@ struct FeedGenerator {
 
     private func generateContentXML() -> String {
         content
-            .prefix(site.feedConfiguration.contentCount)
+            .prefix(feedConfig.contentCount)
             .map { item in
                 var itemXML = """
-            <item>\
-            <guid isPermaLink="true">\(item.path(in: site))</guid>\
-            <title>\(item.title)</title>\
-            <link>\(item.path(in: site))</link>\
-            <description><![CDATA[\(item.description)]]></description>\
-            <pubDate>\(item.date.asRFC822(timeZone: site.timeZone))</pubDate>
-            """
+                <item>\
+                <guid isPermaLink="true">\(item.path(in: site))</guid>\
+                <title>\(item.title)</title>\
+                <link>\(item.path(in: site))</link>\
+                <description><![CDATA[\(item.description)]]></description>\
+                <pubDate>\(item.date.asRFC822(timeZone: site.timeZone))</pubDate>
+                """
 
                 let authorName = item.author ?? site.author
 
@@ -58,7 +65,7 @@ struct FeedGenerator {
                     itemXML += "<category><![CDATA[\(tag)]]></category>"
                 }
 
-                if site.feedConfiguration.mode == .full {
+                if feedConfig.mode == .full {
                     itemXML += """
                     <content:encoded>\
                     <![CDATA[\(item.body.makingAbsoluteLinks(relativeTo: site.url))]]>\
@@ -83,7 +90,7 @@ struct FeedGenerator {
         <description>\(site.description ?? "")</description>\
         <link>\(site.url.absoluteString)</link>\
         <atom:link
-            href="\(site.url.appending(path: site.feedConfiguration.path).absoluteString)"
+            href="\(site.url.appending(path: feedConfig.path).absoluteString)"
             rel="self" type="application/rss+xml"
         />\
         <language>\(site.language.rawValue)</language>\

--- a/Sources/Ignite/Publishing/PublishingContext-Generators.swift
+++ b/Sources/Ignite/Publishing/PublishingContext-Generators.swift
@@ -102,18 +102,18 @@ extension PublishingContext {
 
     /// Generates an RSS feed for this site, if enabled.
     public func generateFeed() {
-        guard site.isFeedEnabled else { return }
+        guard let feedConfig = site.feedConfiguration else { return }
 
         let content = allContent.sorted(
             by: \.date,
             order: .reverse
         )
 
-        let generator = FeedGenerator(site: site, content: content)
+        let generator = FeedGenerator(config: feedConfig, site: site, content: content)
         let result = generator.generateFeed()
 
         do {
-            let destinationURL = buildDirectory.appending(path: site.feedConfiguration.path)
+            let destinationURL = buildDirectory.appending(path: feedConfig.path)
             try result.write(to: destinationURL, atomically: true, encoding: .utf8)
         } catch {
             addError(.failedToWriteFeed)

--- a/Tests/IgniteTesting/Publishing/FeedGenerator.swift
+++ b/Tests/IgniteTesting/Publishing/FeedGenerator.swift
@@ -22,12 +22,13 @@ struct FeedGeneratorTests {
 
     @Test("generateFeed()", arguments: await sites)
     func generateFeed(for site: any Site) async throws {
-        let feedHref = site.url.appending(path: site.feedConfiguration.path).absoluteString
+        let config = site.feedConfiguration!
+        let feedHref = site.url.appending(path: config.path).absoluteString
         var exampleContent = Content()
         exampleContent.title = "Example Title"
         exampleContent.description = "Example Description"
 
-        let generator = FeedGenerator(site: site, content: [exampleContent])
+        let generator = FeedGenerator(config: config, site: site, content: [exampleContent])
 
         #expect(generator.generateFeed() == """
         <?xml version="1.0" encoding="UTF-8" ?>\
@@ -45,11 +46,11 @@ struct FeedGeneratorTests {
         <language>\(site.language.rawValue)</language>\
         <generator>\(Ignite.version)</generator>\
         <image>\
-        <url>\(site.feedConfiguration.image?.url ?? "")</url>\
+        <url>\(config.image?.url ?? "")</url>\
         <title>\(site.name)</title>\
         <link>\(site.url.absoluteString)</link>\
-        <width>\(site.feedConfiguration.image?.width ?? 0)</width>\
-        <height>\(site.feedConfiguration.image?.height ?? 0)</height>\
+        <width>\(config.image?.width ?? 0)</width>\
+        <height>\(config.image?.height ?? 0)</height>\
         </image>\
         <item>\
         <guid isPermaLink="true">\(exampleContent.path(in: site))</guid>\


### PR DESCRIPTION
This PR allows `feedConfiguration` to take on the responsibility of `isFeedEnabled` by making it return a value of `FeedConfiguration?`.

This change improves ergonomics in a few ways:

1. View’s requiring RSS feed information, like `FeedLink`, now need to deal with only one property, instead of two.

2. Disabling an RSS feed by setting `feedConfiguration` to `nil` is much more intuitive than creating a `FeedConfiguration` with a `contentMode` of `disabled`.

3. We can ensure that `FeedConfiguration` instances are initialized only when they have valid `contentCount` values.

Breakages would be little to none—only `FeedConfiguration` instances with a `ContentMode.disabled`.