### PR TITLE
Restore `HTMLBody` to `Body`.

### DIFF
--- a/Sources/Ignite/Elements/Body.swift
+++ b/Sources/Ignite/Elements/Body.swift
@@ -5,7 +5,7 @@
 // See LICENSE for license information.
 //
 
-public struct HTMLBody: RootElement {
+public struct Body: RootElement {
     /// The content and behavior of this HTML.
     public var body: some HTML { self }
 

--- a/Sources/Ignite/Framework/EmptyLayout.swift
+++ b/Sources/Ignite/Framework/EmptyLayout.swift
@@ -9,7 +9,7 @@
 public struct EmptyLayout: Layout {
     public var body: some HTML {
         HTMLDocument {
-            HTMLBody(for: page)
+            Body(for: page)
         }
     }
 

--- a/Sources/Ignite/Framework/Layout.swift
+++ b/Sources/Ignite/Framework/Layout.swift
@@ -14,7 +14,7 @@
 ///     var body: some HTML {
 ///         HTMLDocument {
 ///             Header("My Blog")
-///             HTMLBody(for: page)
+///             Body(for: page)
 ///             Footer()
 ///         }
 ///     }
@@ -23,10 +23,10 @@
 @MainActor
 public protocol Layout {
     /// The type of HTML content this layout will generate
-    associatedtype Body: HTML
+    associatedtype Markup: HTML
 
     /// The main content of the layout, built using the HTML DSL
-    var body: Body { get }
+    var body: Markup { get }
 
     /// A unique identifier for this layout instance
     var id: String { get }

--- a/Tests/IgniteTesting/Elements/Body.swift
+++ b/Tests/IgniteTesting/Elements/Body.swift
@@ -19,7 +19,7 @@ import Testing
    func simpleBody(for site: any Site) async throws {
        try PublishingContext.initialize(for: site, from: #filePath)
 
-       let element = HTMLBody(
+       let element = Body(
            for: Page(
                title: "TITLE", description: "DESCRIPTION",
                url: site.url,

--- a/Tests/IgniteTesting/Elements/HTMLDocument.swift
+++ b/Tests/IgniteTesting/Elements/HTMLDocument.swift
@@ -84,7 +84,7 @@ struct HTMLDocumentTests {
     @Test("places output of contents into contents of html tag")
     func html_tag_contents_are_taken_from_contents_property() async throws {
 
-        let body = HTMLBody { "Hello World" }
+        let body = Body { "Hello World" }
         let sut = HTMLDocument { body }
 
         let expected = body.render()


### PR DESCRIPTION
During the development of Ignite’s imminent new release, `Body` was changed to `HTMLBody` to avoid a collision with `Layout`’s associated type name. The associated type name has been reworked to permit the use of `Body` again, improving ergonomics.