### PR TITLE
Restore `HTMLHead` to `Head`.

### DIFF
--- a/Sources/Ignite/Elements/Head.swift
+++ b/Sources/Ignite/Elements/Head.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// A group of metadata headers for your page, such as its title,
 /// links to its CSS, and more.
-public struct HTMLHead: RootElement {
+public struct Head: RootElement {
     /// The content and behavior of this HTML.
     public var body: some HTML { self }
 
@@ -41,7 +41,7 @@ public struct HTMLHead: RootElement {
         for page: Page,
         @HeadElementBuilder additionalItems: () -> [any HeadElement] = { [] }
     ) {
-        items = HTMLHead.standardHeaders(for: page)
+        items = Head.standardHeaders(for: page)
         items += MetaTag.socialSharingTags(for: page)
         items += additionalItems()
     }

--- a/Tests/IgniteTesting/Elements/Head.swift
+++ b/Tests/IgniteTesting/Elements/Head.swift
@@ -21,7 +21,7 @@ struct HTMLHeadTests {
 
     @Test("Defaults to empty head tag")
     func default_is_empty_head_tag() throws {
-        let sut = HTMLHead {}
+        let sut = Head {}
         let output = sut.render()
 
         let (attributes, contents) = try #require(output.htmlTagWithCloseTag("head"))
@@ -37,7 +37,7 @@ struct HTMLHeadTests {
             Script(file: "../script.js"),
             MetaTag(.openGraphTitle, content: "hello")
         ] }
-        let sut = HTMLHead(items: exampleHeaderItems)
+        let sut = Head(items: exampleHeaderItems)
 
         let contents = try #require(sut.render().htmlTagWithCloseTag("head")?.contents)
 
@@ -48,8 +48,8 @@ struct HTMLHeadTests {
 
     @Test("Output contains standard headers for page passed in on init")
     func output_contains_standard_headers_for_page() throws {
-        let sut = HTMLHead(for: examplePage)
-        let expected = HTMLCollection(HTMLHead.standardHeaders(for: examplePage)).render()
+        let sut = Head(for: examplePage)
+        let expected = HTMLCollection(Head.standardHeaders(for: examplePage)).render()
 
         let output = sut.render()
 
@@ -58,7 +58,7 @@ struct HTMLHeadTests {
 
     @Test("Output contains soccial sharing tags for page passed in on init")
     func output_contains_social_sharing_tags() throws {
-        let sut = HTMLHead(for: examplePage)
+        let sut = Head(for: examplePage)
         let expected = HTMLCollection(MetaTag.socialSharingTags(for: examplePage)).render()
 
         let output = sut.render()
@@ -69,7 +69,7 @@ struct HTMLHeadTests {
     @Test("Output contains any additional items passed in on init")
     func output_contains_additional_items() throws {
         let additionalItem = Script(file: "somefile.js")
-        let sut = HTMLHead(for: examplePage) { additionalItem }
+        let sut = Head(for: examplePage) { additionalItem }
         let expected = additionalItem.render()
 
         let output = sut.render()


### PR DESCRIPTION
During the development of Ignite’s imminent new release, `Head` was changed to `HTMLHead` to complement `HTMLBody`. Recent changes have allowed the prior names of both types to be restored—see #528.