### PR TITLE
Consolidate `EnvironmentStore` into `PublishingContext`.

### DIFF
--- a/Sources/Ignite/Framework/Environment/Environment.swift
+++ b/Sources/Ignite/Framework/Environment/Environment.swift
@@ -21,7 +21,7 @@
 
     /// The current value from the environment store.
     public var wrappedValue: Value {
-        EnvironmentStore.current[keyPath: keyPath]
+        PublishingContext.default.environment[keyPath: keyPath]
     }
 
     /// Creates an environment property with the given key path.

--- a/Sources/Ignite/Framework/Environment/EnvironmentStore.swift
+++ b/Sources/Ignite/Framework/Environment/EnvironmentStore.swift
@@ -1,35 +1,9 @@
-//
-// EnvironmentStore.swift
-// Ignite
-// https://www.github.com/twostraws/Ignite
-// See LICENSE for license information.
+////
+//// EnvironmentStore.swift
+//// Ignite
+//// https://www.github.com/twostraws/Ignite
+//// See LICENSE for license information.
+////
 //
 
-/// A class that manages the storage and updates of environment values.
-///
-/// Environment values are stored in a global singleton that can be temporarily modified
-/// using the `update` method. For example:
-///
-/// ```swift
-/// let result = EnvironmentStore.update(newEnvironment) {
-///     // Code that needs the temporary environment
-///     return someValue
-/// }
-/// ```
-@MainActor
-final class EnvironmentStore {
-    /// The current environment values for the application.
-    static var current = EnvironmentValues()
-
-    /// Temporarily updates the environment values for the duration of an operation.
-    /// - Parameters:
-    ///   - environment: The new environment values to use
-    ///   - operation: A closure that executes with the temporary environment
-    /// - Returns: The value returned by the operation
-    static func update<T>(_ environment: EnvironmentValues, operation: () -> T) -> T {
-        let previous = current
-        current = environment
-        defer { current = previous }
-        return operation()
-    }
-}
+// Retained to avoid unfun conflicts. To be removed

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -58,6 +58,9 @@ final class PublishingContext {
     /// Any errors that have been issued during a build.
     private(set) var errors = [PublishingError]()
 
+    /// The current environment values for the application.
+    var environment = EnvironmentValues()
+
     /// All the Markdown content this user has inside their Content folder.
     private(set) var allContent = [Content]()
 
@@ -301,7 +304,7 @@ final class PublishingContext {
 
         return PageContext.withCurrentPage(page) {
             let values = EnvironmentValues(sourceDirectory: sourceDirectory, site: site, allContent: allContent)
-            return EnvironmentStore.update(values) {
+            return withEnvironment(values) {
                 finalLayout.body.render()
             }
         }
@@ -317,7 +320,7 @@ final class PublishingContext {
         currentRenderingPath = isHomePage ? "/" : staticLayout.path
 
         let values = EnvironmentValues(sourceDirectory: sourceDirectory, site: site, allContent: allContent)
-        let body = EnvironmentStore.update(values) {
+        let body = withEnvironment(values) {
             staticLayout.body
         }
 
@@ -341,7 +344,7 @@ final class PublishingContext {
 
         let body = ContentContext.withCurrentContent(content) {
             let values = EnvironmentValues(sourceDirectory: sourceDirectory, site: site, allContent: allContent)
-            return EnvironmentStore.update(values) {
+            return withEnvironment(values) {
                 Section(layout.body)
             }
         }
@@ -382,5 +385,17 @@ final class PublishingContext {
         } else {
             fatalError(.missingDefaultLayout)
         }
+    }
+
+    /// Temporarily updates the environment values for the duration of an operation.
+    /// - Parameters:
+    ///   - environment: The new environment values to use
+    ///   - operation: A closure that executes with the temporary environment
+    /// - Returns: The value returned by the operation
+    func withEnvironment<T>(_ environment: EnvironmentValues, operation: () -> T) -> T {
+        let previous = self.environment
+        self.environment = environment
+        defer { self.environment = previous }
+        return operation()
     }
 }


### PR DESCRIPTION
Although this PR is self-contained, it feeds into a larger goal of simplifying Ignite's internal architecture, chiefly by eliminating a handful of unnecessary singletons that carry single properties.