### PR TITLE
Consolidate “site” prefixed environment variables into one `\.site` property, mirroring `\.page`.

### DIFF
--- a/Sources/Ignite/Framework/Environment/EnvironmentValues.swift
+++ b/Sources/Ignite/Framework/Environment/EnvironmentValues.swift
@@ -32,17 +32,8 @@ public struct EnvironmentValues {
     /// Locates, loads, and decodes a JSON file in your Resources folder.
     public var decode: DecodeAction
 
-    /// The name of the site
-    public let siteName: String
-
-    /// A string to append to the end of page titles
-    public let siteTitleSuffix: String
-
-    /// An optional description for the site
-    public let siteDescription: String?
-
-    /// The base URL for the site
-    public let siteURL: URL
+    /// The site's metadata, such as name, description, and URL.
+    public let site: SiteMetadata
 
     /// The author of the site
     public let author: String
@@ -77,14 +68,11 @@ public struct EnvironmentValues {
         self.themes = []
         self.decode = .init(sourceDirectory: URL(filePath: ""))
         self.author = ""
-        self.siteName = ""
-        self.siteTitleSuffix = ""
-        self.siteDescription = nil
         self.language = .english
-        self.siteURL = URL(static: "https://example.com")
         self.favicon = nil
         self.builtInIconsEnabled = .localBootstrap
         self.timeZone = .gmt
+        self.site = .empty
     }
 
     init(sourceDirectory: URL, site: any Site, allContent: [Content]) {
@@ -93,14 +81,18 @@ public struct EnvironmentValues {
         self.feedConfiguration = site.feedConfiguration
         self.themes = site.allThemes
         self.author = site.author
-        self.siteName = site.name
-        self.siteTitleSuffix = site.titleSuffix
-        self.siteDescription = site.description
         self.language = site.language
-        self.siteURL = site.url
         self.favicon = site.favicon
         self.builtInIconsEnabled = site.builtInIconsEnabled
         self.timeZone = site.timeZone
+
+        self.site = SiteMetadata(
+            name: site.name,
+            titleSuffix: site.titleSuffix,
+            description: site.description,
+            url: site.url)
+
+
     }
 
     init(sourceDirectory: URL, site: any Site, allContent: [Content], page: Page) {

--- a/Sources/Ignite/Rendering/SiteMetadata.swift
+++ b/Sources/Ignite/Rendering/SiteMetadata.swift
@@ -1,0 +1,31 @@
+//
+// SiteMetadata.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+/// The core metadata of your website, such as name, description, and URL.
+public struct SiteMetadata: Sendable {
+    /// The name of the site
+    private(set) public var name: String
+
+    /// A string to append to the end of page titles
+    private(set) public var titleSuffix: String
+
+    /// An optional description for the site
+    private(set) public var description: String?
+
+    /// The base URL for the site
+    private(set) public var url: URL
+}
+
+extension SiteMetadata {
+    /// Creates an empty page for use as a default value
+    @MainActor static let empty = SiteMetadata(
+        name: "",
+        titleSuffix: "",
+        description: "",
+        url: URL(string: "about:blank")!
+    )
+}


### PR DESCRIPTION
To create symmetry and consistency with #599.