### PR TITLE
Improve names of -`Layout` types.

### DIFF
--- a/Sources/Ignite/Elements/Link.swift
+++ b/Sources/Ignite/Elements/Link.swift
@@ -92,7 +92,7 @@ public struct Link: InlineElement, NavigationItem, DropdownItem {
     /// - Parameters:
     ///  - target: The new target to apply.
     ///  - content: The user-facing content to show inside the `Link`.
-    public init(target: any StaticLayout, @HTMLBuilder content: @escaping () -> some HTML) {
+    public init(target: any Page, @HTMLBuilder content: @escaping () -> some HTML) {
         self.content = content()
         self.url = target.path
         self.role = .none
@@ -226,7 +226,7 @@ public extension Link {
     /// - Parameters:
     ///   - content: The user-facing content to show inside the `Link`.
     ///   - target: The `Page` you want to link to.
-    init(_ content: some InlineElement, target: any StaticLayout) {
+    init(_ content: some InlineElement, target: any Page) {
         self.content = content
         self.url = target.path
     }

--- a/Sources/Ignite/Framework/ArchiveLayout.swift
+++ b/Sources/Ignite/Framework/ArchiveLayout.swift
@@ -20,15 +20,23 @@
 /// }
 /// ```
 @MainActor
-public protocol TagLayout: LayoutContent {}
+public protocol ArchiveLayout: LayoutContent {
+    /// The page layout to use for this tag page.
+    var pageLayout: any Layout { get }
+}
 
-extension TagLayout {
+public extension ArchiveLayout {
     /// The current tag during page generation.
-    public var tag: String? {
+    var tag: String? {
         PublishingContext.shared.environment.tag
     }
 
-    public var content: [Article] {
+    var content: [Article] {
         PublishingContext.shared.environment.taggedContent
+    }
+
+    // Defaults to the site's main layout.
+    var pageLayout: any Layout {
+        PublishingContext.shared.site.layout
     }
 }

--- a/Sources/Ignite/Framework/ArticleLayout.swift
+++ b/Sources/Ignite/Framework/ArticleLayout.swift
@@ -26,4 +26,9 @@ public extension ArticleLayout {
     var article: Article {
         PublishingContext.shared.environment.article
     }
+
+    // Defaults to the site's main layout.
+    var pageLayout: any Layout {
+        PublishingContext.shared.site.layout
+    }
 }

--- a/Sources/Ignite/Framework/EmptyArchiveLayout.swift
+++ b/Sources/Ignite/Framework/EmptyArchiveLayout.swift
@@ -5,8 +5,8 @@
 // See LICENSE for license information.
 //
 
-/// A default tag layout that does nothing; used to disable tag pages entirely.
-public struct EmptyTagLayout: ArchiveLayout {
+/// A default archive layout that does nothing; used to disable archive pages entirely.
+public struct EmptyArchiveLayout: ArchiveLayout {
     public var body: some HTML {
         EmptyHTML()
     }

--- a/Sources/Ignite/Framework/EmptyTagLayout.swift
+++ b/Sources/Ignite/Framework/EmptyTagLayout.swift
@@ -6,7 +6,7 @@
 //
 
 /// A default tag layout that does nothing; used to disable tag pages entirely.
-public struct EmptyTagLayout: TagLayout {
+public struct EmptyTagLayout: ArchiveLayout {
     public var body: some HTML {
         EmptyHTML()
     }

--- a/Sources/Ignite/Framework/Environment/EnvironmentValues.swift
+++ b/Sources/Ignite/Framework/Environment/EnvironmentValues.swift
@@ -52,7 +52,7 @@ public struct EnvironmentValues {
     /// The current page being rendered.
     internal(set) public var page: PageMetadata
 
-    /// The content of the current page being rendered.
+    /// The page content of the current layout being rendered.
     var pageContent: any HTML = EmptyHTML()
 
     /// The current piece of Markdown content being rendered.
@@ -81,12 +81,12 @@ public struct EnvironmentValues {
     init(
         sourceDirectory: URL,
         site: any Site,
-        allContent: [Article],
+        allArticles: [Article],
         pageMetadata: PageMetadata,
         pageContent: any LayoutContent
     ) {
         self.decode = DecodeAction(sourceDirectory: sourceDirectory)
-        self.articles = ArticleLoader(content: allContent)
+        self.articles = ArticleLoader(content: allArticles)
         self.feedConfiguration = site.feedConfiguration
         self.themes = site.allThemes
         self.author = site.author
@@ -110,13 +110,13 @@ public struct EnvironmentValues {
     init(
         sourceDirectory: URL,
         site: any Site,
-        allContent: [Article],
+        allArticles: [Article],
         pageMetadata: PageMetadata,
         pageContent: any LayoutContent,
         article: Article
     ) {
         self.decode = DecodeAction(sourceDirectory: sourceDirectory)
-        self.articles = ArticleLoader(content: allContent)
+        self.articles = ArticleLoader(content: allArticles)
         self.feedConfiguration = site.feedConfiguration
         self.themes = site.allThemes
         self.author = site.author
@@ -142,14 +142,14 @@ public struct EnvironmentValues {
     init(
         sourceDirectory: URL,
         site: any Site,
-        allContent: [Article],
+        allArticles: [Article],
         pageMetadata: PageMetadata,
         pageContent: any LayoutContent,
         tag: String?,
         taggedContent: [Article]
     ) {
         self.decode = DecodeAction(sourceDirectory: sourceDirectory)
-        self.articles = ArticleLoader(content: allContent)
+        self.articles = ArticleLoader(content: allArticles)
         self.feedConfiguration = site.feedConfiguration
         self.themes = site.allThemes
         self.author = site.author

--- a/Sources/Ignite/Framework/LayoutContent.swift
+++ b/Sources/Ignite/Framework/LayoutContent.swift
@@ -14,11 +14,3 @@ public protocol LayoutContent: Sendable {
     /// The content and behavior of this `HTML` element.
     @HTMLBuilder var body: Body { get }
 }
-
-public extension LayoutContent {
-    // Default to `MissingLayout`, which will cause the main
-    // site layout to be used instead.
-    var parentLayout: any Layout {
-        PublishingContext.shared.site.layout
-    }
-}

--- a/Sources/Ignite/Framework/Page.swift
+++ b/Sources/Ignite/Framework/Page.swift
@@ -10,7 +10,7 @@ import Foundation
 /// One static layout in your site, where the content is entirely standalone rather
 /// than being produced in conjunction with an external Markdown file.
 @MainActor
-public protocol StaticLayout: LayoutContent {
+public protocol Page: LayoutContent {
     /// All layouts have a default path generated for them by Ignite, but you can
     /// override that here if you wish.
     var path: String { get }
@@ -23,9 +23,12 @@ public protocol StaticLayout: LayoutContent {
 
     /// A plain-text description for this layout. Defaults to an empty string.
     var description: String { get }
+
+    /// The layout to use for this page.
+    var layout: any Layout { get }
 }
 
-public extension StaticLayout {
+public extension Page {
     /// A default description for this layout, which is just an empty string.
     var description: String { "" }
 
@@ -45,4 +48,9 @@ public extension StaticLayout {
 
     /// Defaults to no sharing image
     var image: URL? { nil }
+
+    // Defaults to the site's main layout.
+    var layout: any Layout {
+        PublishingContext.shared.site.layout
+    }
 }

--- a/Sources/Ignite/Framework/Site.swift
+++ b/Sources/Ignite/Framework/Site.swift
@@ -33,7 +33,7 @@ import Foundation
 @MainActor
 public protocol Site: Sendable {
     /// The type of your homepage. Required.
-    associatedtype HomePageLayout: Page
+    associatedtype HomePage: Page
 
     /// The type used to generate your archive pages. A default is provided that means
     /// no archive pages are generated.
@@ -100,7 +100,7 @@ public protocol Site: Sendable {
     var robotsConfiguration: RobotsType { get }
 
     /// The homepage for your site; what users land on when visiting your root domain.
-    var homePage: HomePageLayout { get }
+    var homePage: HomePage { get }
 
     /// A type that conforms to `ArchiveLayout`, to be used when rendering individual
     /// archive pages or the "all tags" page.

--- a/Sources/Ignite/Framework/Site.swift
+++ b/Sources/Ignite/Framework/Site.swift
@@ -35,9 +35,9 @@ public protocol Site: Sendable {
     /// The type of your homepage. Required.
     associatedtype HomePageLayout: Page
 
-    /// The type used to generate your tag pages. A default is provided that means
-    /// no tags pages are generated.
-    associatedtype TagPageLayout: ArchiveLayout
+    /// The type used to generate your archive pages. A default is provided that means
+    /// no archive pages are generated.
+    associatedtype ArchivePageLayout: ArchiveLayout
 
     /// The type that defines the base layout structure for all pages.
     associatedtype LayoutType: Layout
@@ -102,9 +102,9 @@ public protocol Site: Sendable {
     /// The homepage for your site; what users land on when visiting your root domain.
     var homePage: HomePageLayout { get }
 
-    /// A type that conforms to `TagLayout`, to be used when rendering individual
-    /// tag pages or the "all tags" page.
-    var tagLayout: TagPageLayout { get }
+    /// A type that conforms to `ArchiveLayout`, to be used when rendering individual
+    /// archive pages or the "all tags" page.
+    var archiveLayout: ArchivePageLayout { get }
 
     /// The base layout applied to all pages. This is used to render all pages that don't
     /// explicitly override the layout with something custom.
@@ -136,8 +136,8 @@ public protocol Site: Sendable {
     /// The path to the favicon
     var favicon: URL? { get }
 
-    /// An array of all the static layouts you want to include in your site.
-    @StaticLayoutBuilder var staticLayouts: [any Page] { get }
+    /// An array of all the pages you want to include in your site.
+    @PageBuilder var pages: [any Page] { get }
 
     /// An array of all the content layouts you want to include in your site.
     @ArticleLayoutBuilder var articleLayouts: [any ArticleLayout] { get }
@@ -195,14 +195,14 @@ public extension Site {
     /// A default robots.txt configuration that allows all robots to index all pages.
     var robotsConfiguration: DefaultRobotsConfiguration { DefaultRobotsConfiguration() }
 
-    /// No static layouts by default.
-    var staticLayouts: [any Page] { [] }
+    /// No pages by default.
+    var pages: [any Page] { [] }
 
     /// No content layouts by default.
     var articleLayouts: [any ArticleLayout] { [] }
 
-    /// An empty tag layout by default, which triggers no tag pages being made.
-    var tagLayout: EmptyTagLayout { EmptyTagLayout() }
+    /// An empty archive layout by default, which triggers no archive pages being made.
+    var archiveLayout: EmptyArchiveLayout { EmptyArchiveLayout() }
 
     /// The default favicon being nil
     var favicon: URL? { nil }

--- a/Sources/Ignite/Framework/Site.swift
+++ b/Sources/Ignite/Framework/Site.swift
@@ -33,11 +33,11 @@ import Foundation
 @MainActor
 public protocol Site: Sendable {
     /// The type of your homepage. Required.
-    associatedtype HomePageLayout: StaticLayout
+    associatedtype HomePageLayout: Page
 
     /// The type used to generate your tag pages. A default is provided that means
     /// no tags pages are generated.
-    associatedtype TagPageLayout: TagLayout
+    associatedtype TagPageLayout: ArchiveLayout
 
     /// The type that defines the base layout structure for all pages.
     associatedtype LayoutType: Layout
@@ -137,7 +137,7 @@ public protocol Site: Sendable {
     var favicon: URL? { get }
 
     /// An array of all the static layouts you want to include in your site.
-    @StaticLayoutBuilder var staticLayouts: [any StaticLayout] { get }
+    @StaticLayoutBuilder var staticLayouts: [any Page] { get }
 
     /// An array of all the content layouts you want to include in your site.
     @ArticleLayoutBuilder var articleLayouts: [any ArticleLayout] { get }
@@ -196,7 +196,7 @@ public extension Site {
     var robotsConfiguration: DefaultRobotsConfiguration { DefaultRobotsConfiguration() }
 
     /// No static layouts by default.
-    var staticLayouts: [any StaticLayout] { [] }
+    var staticLayouts: [any Page] { [] }
 
     /// No content layouts by default.
     var articleLayouts: [any ArticleLayout] { [] }

--- a/Sources/Ignite/Publishing/PublishingContext-Generators.swift
+++ b/Sources/Ignite/Publishing/PublishingContext-Generators.swift
@@ -39,11 +39,11 @@ extension PublishingContext {
     func generateContent() async {
         render(site.homePage, isHomePage: true)
 
-        for page in site.staticLayouts {
+        for page in site.pages {
             render(page)
         }
 
-        for content in allContent {
+        for content in allArticles {
             render(content)
         }
         currentRenderingPath = nil
@@ -69,7 +69,7 @@ extension PublishingContext {
     public func generateFeed() {
         guard let feedConfig = site.feedConfiguration else { return }
 
-        let content = allContent.sorted(
+        let content = allArticles.sorted(
             by: \.date,
             order: .reverse
         )

--- a/Sources/Ignite/Publishing/PublishingContext-Rendering.swift
+++ b/Sources/Ignite/Publishing/PublishingContext-Rendering.swift
@@ -27,7 +27,7 @@ extension PublishingContext {
         let values = EnvironmentValues(
             sourceDirectory: sourceDirectory,
             site: site,
-            allContent: allContent,
+            allArticles: allArticles,
             pageMetadata: metadata,
             pageContent: staticLayout)
 
@@ -55,7 +55,7 @@ extension PublishingContext {
         let values = EnvironmentValues(
             sourceDirectory: sourceDirectory,
             site: site,
-            allContent: allContent,
+            allArticles: allArticles,
             pageMetadata: metadata,
             pageContent: layout,
             article: article)
@@ -70,11 +70,11 @@ extension PublishingContext {
 
     /// Generates all tags pages, including the "all tags" page.
     func renderTagLayouts() async {
-        if site.tagLayout is EmptyTagLayout { return }
+        if site.archiveLayout is EmptyArchiveLayout { return }
 
         /// Creates a unique list of sorted tags from across the site, starting
         /// with `nil` for the "all tags" page.
-        let tags: [String?] = [nil] + Set(allContent.flatMap(\.tags)).sorted()
+        let tags: [String?] = [nil] + Set(allArticles.flatMap(\.tags)).sorted()
 
         for tag in tags {
             let path: String = if let tag {
@@ -84,7 +84,7 @@ extension PublishingContext {
             }
 
             let outputDirectory = buildDirectory.appending(path: path)
-            let tagLayout = site.tagLayout
+            let tagLayout = site.archiveLayout
 
             let metadata = PageMetadata(
                 title: "Tags",
@@ -95,7 +95,7 @@ extension PublishingContext {
             let values = EnvironmentValues(
                 sourceDirectory: sourceDirectory,
                 site: site,
-                allContent: allContent,
+                allArticles: allArticles,
                 pageMetadata: metadata,
                 pageContent: tagLayout,
                 tag: tag,

--- a/Sources/Ignite/Publishing/PublishingContext-Rendering.swift
+++ b/Sources/Ignite/Publishing/PublishingContext-Rendering.swift
@@ -13,7 +13,7 @@ extension PublishingContext {
     ///   - page: The page to render.
     ///   - isHomePage: True if this is your site's homepage; this affects the
     ///   final path that is written to.
-    func render(_ staticLayout: any StaticLayout, isHomePage: Bool = false) {
+    func render(_ staticLayout: any Page, isHomePage: Bool = false) {
         let path = isHomePage ? "" : staticLayout.path
         currentRenderingPath = isHomePage ? "/" : staticLayout.path
 
@@ -32,7 +32,7 @@ extension PublishingContext {
             pageContent: staticLayout)
 
         let outputString = withEnvironment(values) {
-            staticLayout.parentLayout.body.render()
+            staticLayout.layout.body.render()
         }
 
         let outputDirectory = buildDirectory.appending(path: path)
@@ -61,7 +61,7 @@ extension PublishingContext {
             article: article)
 
         let outputString = withEnvironment(values) {
-            layout.parentLayout.body.render()
+            layout.pageLayout.body.render()
         }
 
         let outputDirectory = buildDirectory.appending(path: article.path)
@@ -102,7 +102,7 @@ extension PublishingContext {
                 taggedContent: content(tagged: tag))
 
             let outputString = withEnvironment(values) {
-                tagLayout.parentLayout.body.render()
+                tagLayout.pageLayout.body.render()
             }
 
             write(outputString, to: outputDirectory, priority: tag == nil ? 0.7 : 0.6)

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -62,7 +62,7 @@ final class PublishingContext {
     var environment = EnvironmentValues()
 
     /// All the Markdown content this user has inside their Content folder.
-    private(set) var allContent = [Article]()
+    private(set) var allArticles = [Article]()
 
     /// An ordered set of syntax highlighters pulled from code blocks throughout the site.
     var syntaxHighlighters = OrderedSet<HighlighterLanguage>()
@@ -123,9 +123,9 @@ final class PublishingContext {
     /// if no tag was specified.
     func content(tagged tag: String?) -> [Article] {
         if let tag {
-            allContent.filter { $0.tags.contains(tag) }
+            allArticles.filter { $0.tags.contains(tag) }
         } else {
-            allContent
+            allArticles
         }
     }
 
@@ -173,13 +173,13 @@ final class PublishingContext {
                 deployPath: deploy.path
             )
             if article.isPublished {
-                allContent.append(article)
+                allArticles.append(article)
             }
             return true // always continuing
         }
 
         // Make content be sorted newest first by default.
-        allContent.sort(
+        allArticles.sort(
             by: \.date,
             order: .reverse
         )

--- a/Sources/Ignite/Rendering/ResultBuilders/ElementBuilder.swift
+++ b/Sources/Ignite/Rendering/ResultBuilders/ElementBuilder.swift
@@ -7,7 +7,7 @@
 
 typealias HeadElementBuilder = ElementBuilder<any HeadElement>
 typealias DocumentElementBuilder = ElementBuilder<any DocumentElement>
-typealias StaticLayoutBuilder = ElementBuilder<any StaticLayout>
+typealias PageBuilder = ElementBuilder<any Page>
 typealias ArticleLayoutBuilder = ElementBuilder<any ArticleLayout>
 typealias ActionBuilder = ElementBuilder<any Action>
 

--- a/Tests/IgniteTesting/Elements/Link.swift
+++ b/Tests/IgniteTesting/Elements/Link.swift
@@ -14,7 +14,7 @@ import Testing
 @Suite("Link Tests")
 @MainActor class SubsiteLinkTests: IgniteTestSuite {
     static let sites: [any Site] = [TestSite(), TestSubsite()]
-    static let pages: [any StaticLayout] = [TestLayout(), TestSubsiteLayout()]
+    static let pages: [any Page] = [TestLayout(), TestSubsiteLayout()]
 
     @Test("String Target", arguments: [(target: "/", description: "Go Home")], await Self.sites)
     func target(for link: (target: String, description: String), for site: any Site) async throws {
@@ -34,7 +34,7 @@ import Testing
     }
 
     @Test("Page Target", arguments: zip(await pages, await Self.sites))
-    func target(for page: any StaticLayout, site: any Site) async throws {
+    func target(for page: any Page, site: any Site) async throws {
         try PublishingContext.initialize(for: site, from: #filePath)
 
         let element = Link("This is a test", target: page).linkStyle(.button)
@@ -46,7 +46,7 @@ import Testing
     }
 
     @Test("Page Content", arguments: zip(await pages, await Self.sites))
-    func content(for page: any StaticLayout, site: any Site) async throws {
+    func content(for page: any Page, site: any Site) async throws {
         try PublishingContext.initialize(for: site, from: #filePath)
 
         let element = Link(
@@ -69,7 +69,7 @@ import Testing
     }
 
     @Test("Link Warning Role", arguments: zip(await pages, await Self.sites))
-    func warningRoleLink(for page: any StaticLayout, site: any Site) async throws {
+    func warningRoleLink(for page: any Page, site: any Site) async throws {
         try PublishingContext.initialize(for: site, from: #filePath)
 
         let element = Link("Link with warning role.", target: page).role(.warning)

--- a/Tests/IgniteTesting/TestSubsite.swift
+++ b/Tests/IgniteTesting/TestSubsite.swift
@@ -20,7 +20,7 @@ struct TestSubsite: Site {
 }
 
 /// An example page used in tests.
-struct TestSubsiteLayout: StaticLayout {
+struct TestSubsiteLayout: Page {
     var title = "Subsite Home"
 
     var body: some HTML {

--- a/Tests/IgniteTesting/TestWebsitePackage/Sources/TestSite.swift
+++ b/Tests/IgniteTesting/TestWebsitePackage/Sources/TestSite.swift
@@ -37,7 +37,7 @@ struct TestSite: Site {
 }
 
 /// An example page used in tests.
-struct TestLayout: StaticLayout {
+struct TestLayout: Page {
     var title = "Home"
 
     var body: some HTML {


### PR DESCRIPTION

Based on our conversations, I’ve circled on some promising names for our layout types:

#### `StaticLayout` to `Page`
- Unlike the other two types, `Page`s are not reusable layouts; they are individual pages.
- `StaticLayout.parentLayout` becomes `Page.layout`. Very clear.

#### `ArticleLayout`
- Type name remains the same.
- `ArticleLayout.parentLayout` become `ArticleLayout.pageLayout` to create clear relationship between layouts.

The one that might require further discussion:

#### `TagLayout` to `ArchiveLayout`
- Broader name with long-term stability #603
- Lacks ambiguity of `TagLayout`—this isn't the layout of a tag.
- Creates a namespace distinct from `Tag`, the `HTML` type.
- `TagLayout.parentLayout` become `ArchiveLayout.pageLayout` to create clear relationship between layouts.