### PR TITLE
Set HTML lang attribute based on Site language.

### DIFF
--- a/Sources/Ignite/Elements/Document.swift
+++ b/Sources/Ignite/Elements/Document.swift
@@ -25,7 +25,7 @@ struct Document: HTML {
 
     func render() -> String {
         var attributes = attributes
-        attributes.add(customAttributes: .init(name: "lang", value: language.rawValue))
+        attributes.add(customAttributes: .init(name: "lang", value: self.publishingContext.site.language.rawValue))
         attributes.add(customAttributes: .init(name: "data-bs-theme", value: "auto"))
         var output = "<!doctype html>"
         output += "<html \(attributes)>"


### PR DESCRIPTION
Hello,

By default, the HTML document language defaults to English:

`<html lang="en">`

The `Site` struct allows setting a language via the `language` variable, however this is never taken into account and the language always defaults to English. 

This pull requests provides a way to take into account the `Site` language and to set it as the language of the HTML document.

I understand that there is a more extensive language management underway, so consider this as a temporary way to address the issue. 

Thanks!

