### PR TITLE
Add convenience property to disable auto-margins on `VStack` / `ZStack` children.

### DIFF
--- a/Sources/Ignite/Elements/VStack.swift
+++ b/Sources/Ignite/Elements/VStack.swift
@@ -22,6 +22,10 @@ public struct VStack: HTML {
     /// The child elements contained in the stack.
     private var content: HTMLCollection
 
+    /// Whether the `VStack` should ignore any margins automatically
+    /// applied to its children, like the bottom margin of a paragraph.
+    private var shouldIgnoreMargins: Bool = false
+
     /// Creates a new `Section` object using a block element builder
     /// that returns an array of items to use in this section.
     /// - Parameter items: The items to use in this section.
@@ -34,8 +38,15 @@ public struct VStack: HTML {
     /// that returns an array of items to use in this section.
     /// - Parameters:
     ///   - pixels: The number of pixels between elements.
+    ///   - ignoreMargins: Whether the `VStack` should ignore any margins automatically
+    /// applied to its children, like the bottom margin of a paragraph.
     ///   - items: The items to use in this section.
-    public init(spacing pixels: Int, @HTMLBuilder items: () -> some HTML) {
+    public init(
+        spacing pixels: Int,
+        ignoreMargins: Bool = false,
+        @HTMLBuilder items: () -> some HTML
+    ) {
+        self.shouldIgnoreMargins = ignoreMargins
         self.content = HTMLCollection(items)
         self.spacingAmount = .exact(pixels)
     }
@@ -45,12 +56,18 @@ public struct VStack: HTML {
     /// - Parameters:
     ///   - spacing: The predefined size between elements.
     ///   - items: The items to use in this section.
-    public init(spacing: SpacingAmount, @HTMLBuilder items: () -> some HTML) {
+    public init(spacing: SpacingAmount, ignoreMargins: Bool = false, @HTMLBuilder items: () -> some HTML) {
+        self.shouldIgnoreMargins = ignoreMargins
         self.content = HTMLCollection(items)
         self.spacingAmount = .semantic(spacing)
     }
 
     public func render() -> String {
+        var content = content
+        if shouldIgnoreMargins {
+            content.attributes.add(classes: "mb-0")
+        }
+
         var attributes = attributes
         attributes.add(classes: "vstack")
 

--- a/Sources/Ignite/Elements/ZStack.swift
+++ b/Sources/Ignite/Elements/ZStack.swift
@@ -23,11 +23,21 @@ public struct ZStack: HTML {
     /// The child elements to be stacked.
     private var items: HTMLCollection
 
+    /// Whether the `ZStack` should ignore any margins automatically
+    /// applied to its children, like the bottom margin of a paragraph.
+    private var shouldIgnoreMargins: Bool = false
+
     /// Creates a new ZStack with the specified alignment and content.
     /// - Parameters:
     ///   - alignment: The point within the stack where elements should be aligned (default: .center).
+    ///   - ignoreMargins: Whether the `VStack` should ignore any margins automatically
+    /// applied to its children, like the bottom margin of a paragraph.
     ///   - items: A closure that returns the elements to be stacked.
-    public init(alignment: Alignment = .center, @HTMLBuilder _ items: () -> some HTML) {
+    public init(
+        alignment: Alignment = .center,
+        ignoreMargins: Bool = false,
+        @HTMLBuilder _ items: () -> some HTML
+    ) {
         self.items = HTMLCollection(items)
         self.alignment = alignment
     }
@@ -43,6 +53,10 @@ public struct ZStack: HTML {
                 .init(.gridArea, value: "1/1"),
                 .init(.zIndex, value: "\(index)")
             ])
+
+            if shouldIgnoreMargins {
+                elementAttributes.add(styles: .init(.marginBottom, value: "0"))
+            }
 
             elementAttributes.add(styles: alignment.flexAlignmentRules)
             return item.attributes(elementAttributes)


### PR DESCRIPTION
This turned out to be a huge pain point while migrating my sites—particularly for `VStack`, which offers spacing of its own. I think this solution provides a convenient fix while keeping the default behavior as expected.