### PR TITLE
Remove hardcoded theme value in `NavigationBar`. Remove theme attribute from `Document`.

### DIFF
--- a/Sources/Ignite/Elements/Document.swift
+++ b/Sources/Ignite/Elements/Document.swift
@@ -26,7 +26,6 @@ struct Document: HTML {
     func render() -> String {
         var attributes = attributes
         attributes.add(customAttributes: .init(name: "lang", value: language.rawValue))
-        attributes.add(customAttributes: .init(name: "data-bs-theme", value: "auto"))
         var output = "<!doctype html>"
         output += "<html \(attributes)>"
         output += contents.map { $0.render() }.joined()

--- a/Sources/Ignite/Elements/Dropdown.swift
+++ b/Sources/Ignite/Elements/Dropdown.swift
@@ -51,6 +51,19 @@ public struct Dropdown: HTML, NavigationItem {
         self.items = items()
     }
 
+    /// Creates a new dropdown button using a title and an element that builder
+    /// that returns an array of types conforming to `DropdownItem`.
+    /// - Parameters:
+    ///   - items: The elements to place inside the dropdown menu.
+    ///   - title: The title to show on this dropdown button.
+    public init(
+        @ElementBuilder<any DropdownItem> items: () -> [any DropdownItem],
+        @InlineElementBuilder title: () -> any InlineElement
+    ) {
+        self.items = items()
+        self.title = title()
+    }
+
     /// Adjusts the size of this dropdown.
     /// - Parameter size: The new size.
     /// - Returns: A new `Dropdown` instance with the updated size.
@@ -101,15 +114,18 @@ public struct Dropdown: HTML, NavigationItem {
     private func renderDropdownContent() -> some HTML {
         Group {
             if isNavigationItem {
+                let titleAttributes = title.attributes
+                let title = title.clearingAttributes()
                 let hasActiveItem = items.contains {
                     publishingContext.currentRenderingPath == ($0 as? Link)?.url
                 }
 
-                Link(title, target: "#")
+                Link(title.style(.display, "inline"), target: "#")
                     .customAttribute(name: "role", value: "button")
                     .class("dropdown-toggle", "nav-link", hasActiveItem ? "active" : nil)
                     .data("bs-toggle", "dropdown")
                     .aria(.expanded, "false")
+                    .attributes(titleAttributes)
             } else {
                 Button(title)
                     .class(Button.classes(forRole: role, size: size))
@@ -136,5 +152,14 @@ public struct Dropdown: HTML, NavigationItem {
             .listMarkerStyle(.unordered(.automatic))
             .class("dropdown-menu")
         }
+    }
+}
+
+private extension InlineElement {
+    /// Returns a copy of the element with all attributes removed.
+    func clearingAttributes() -> some InlineElement {
+        var copy = self
+        copy.attributes = CoreAttributes()
+        return copy
     }
 }

--- a/Sources/Ignite/Elements/Link.swift
+++ b/Sources/Ignite/Elements/Link.swift
@@ -227,7 +227,7 @@ public extension Link {
     /// - Parameters:
     ///   - content: The user-facing content to show inside the `Link`.
     ///   - target: The URL you want to link to.
-    init(_ content: some HTML, target: String) {
+    init(_ content: any InlineElement, target: String) {
         self.content = content
         self.url = target
     }

--- a/Sources/Ignite/Elements/NavigationBar.swift
+++ b/Sources/Ignite/Elements/NavigationBar.swift
@@ -210,7 +210,6 @@ public struct NavigationBar: HTML {
             dropdownItem.configuredAsNavigationItem()
         }
         .class("nav-item", "dropdown")
-        .data("bs-theme", "light")
     }
 
     private func renderLinkItem(_ link: Link) -> some HTML {

--- a/Sources/Ignite/Modifiers/ForegroundStyle.swift
+++ b/Sources/Ignite/Modifiers/ForegroundStyle.swift
@@ -58,6 +58,36 @@ public extension HTML {
     }
 }
 
+public extension InlineElement {
+    /// Applies a foreground color to the current element.
+    /// - Parameter color: The style to apply, specified as a `Color` object.
+    /// - Returns: The current element with the updated color applied.
+    func foregroundStyle(_ color: Color) -> some InlineElement {
+        AnyHTML(foregroundStyleModifier(.color(color)))
+    }
+
+    /// Applies a foreground color to the current element.
+    /// - Parameter color: The style to apply, specified as a string.
+    /// - Returns: The current element with the updated color applied.
+    func foregroundStyle(_ color: String) -> some InlineElement {
+        AnyHTML(foregroundStyleModifier(.string(color)))
+    }
+
+    /// Applies a foreground color to the current element.
+    /// - Parameter style: The style to apply, specified as a `Color` object.
+    /// - Returns: The current element with the updated color applied.
+    func foregroundStyle(_ style: ForegroundStyle) -> some InlineElement {
+        AnyHTML(foregroundStyleModifier(.style(style)))
+    }
+
+    /// Applies a foreground color to the current element.
+    /// - Parameter gradient: The style to apply, specified as a `Gradient` object.
+    /// - Returns: The current element with the updated color applied.
+    func foregroundStyle(_ gradient: Gradient) -> some InlineElement {
+        AnyHTML(foregroundStyleModifier(.gradient(gradient)))
+    }
+}
+
 public extension HTML where Self == Image {
     /// Applies a foreground color to the current element.
     /// - Parameter color: The style to apply, specified as a `Color` object.

--- a/Tests/IgniteTesting/Elements/HTMLDocument.swift
+++ b/Tests/IgniteTesting/Elements/HTMLDocument.swift
@@ -28,18 +28,6 @@ class HTMLDocumentTests: IgniteTestSuite {
         #expect(nil != output.htmlTagWithCloseTag("html"))
     }
 
-    @Test("theme attribute is `auto`")
-    func theme_is_auto() throws {
-        let sut = Document {}
-        let output = sut.render()
-
-        let theme = try #require(output.htmlTagWithCloseTag("html")?.attributes
-            .htmlAttribute(named: "data-bs-theme")
-        )
-
-        #expect(theme == "auto")
-    }
-
     @Test("lang attribute defaults to en")
     func language_attribute_defaults_to_en() throws {
         let sut = Document {}


### PR DESCRIPTION
`navigationBarStyle(.dark)` will override:
 
1. The drop-down button text color
2. The background of the drop-down and the the text color of each drop-down item

So in IgniteSamples, the above modifier will not only make the drop-down button text white—which looks good against a red background—but it will also make the drop-down modal off-black in both dark and light modes.

Is that the behavior we want? If not, should we update the above modifier to be something like this?

```swift
navigationBarStyle(_ style: NavigationBarStyle, for component: NavigationBarComponent)
```

Where `NavigationComponent` has cases like `.button`, `menu`, `.all`?