### PR TITLE
Create `Label` type to easily place `Text` and `Image` side by side.

### DIFF
--- a/Sources/Ignite/Elements/Image.swift
+++ b/Sources/Ignite/Elements/Image.swift
@@ -58,6 +58,7 @@ public struct Image: InlineElement, LazyLoadable {
     /// of your site, e.g. /images/dog.jpg.
     public init(decorative name: String) {
         self.path = URL(string: name)
+        self.description = ""
     }
 
     /// Allows this image to be scaled up or down from its natural size in

--- a/Sources/Ignite/Elements/Image.swift
+++ b/Sources/Ignite/Elements/Image.swift
@@ -48,7 +48,7 @@ public struct Image: InlineElement, LazyLoadable {
     ///   - description: An description of your image suitable for screen readers.
     public init(systemName: String, description: String? = nil) {
         self.systemImage = systemName
-        self.description = ""
+        self.description = description
     }
 
     /// Creates a new decorative `Image` instance from the name of an
@@ -58,7 +58,6 @@ public struct Image: InlineElement, LazyLoadable {
     /// of your site, e.g. /images/dog.jpg.
     public init(decorative name: String) {
         self.path = URL(string: name)
-        self.description = ""
     }
 
     /// Allows this image to be scaled up or down from its natural size in

--- a/Sources/Ignite/Elements/Label.swift
+++ b/Sources/Ignite/Elements/Label.swift
@@ -1,0 +1,71 @@
+//
+// Label.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+/// A view that displays an icon and text side by side, with a default
+/// spacing of 10 pixels in-between. To adjust the spacing, use `margin()`
+/// on either `title` or `icon`.
+public struct Label: InlineElement {
+    /// The content and behavior of this HTML.
+    public var body: some HTML { self }
+
+    /// The standard set of control attributes for HTML elements.
+    public var attributes = CoreAttributes()
+
+    /// Whether this HTML belongs to the framework.
+    public var isPrimitive: Bool { true }
+
+    /// The text content to display alongside the icon.
+    private var title: any InlineElement
+
+    /// The icon element to display before the title.
+    private var icon: any InlineElement
+
+    /// Creates a label with a string title and image icon.
+    /// - Parameters:
+    ///   - title: The text to display in the label.
+    ///   - image: The image to use as the label's icon.
+    public init(_ title: String, image: Image) {
+        self.title = title
+        self.icon = image
+    }
+
+    /// Creates a label with custom title and icon content.
+    /// - Parameters:
+    ///   - title: A closure that returns the label's text content.
+    ///   - icon: A closure that returns the label's icon content.
+    public init(
+        @InlineElementBuilder title: () -> some InlineElement,
+        @InlineElementBuilder icon: () -> some InlineElement
+    ) {
+        self.title = title()
+        self.icon = icon()
+    }
+
+    public func render() -> String {
+        var title = title
+
+        if !(title is String) {
+            title.attributes.add(classes: "mb-0")
+        }
+
+        var icon = icon
+
+        if !(icon is String) {
+            icon.attributes.add(classes: "mb-0")
+        }
+
+        if !icon.attributes.styles.contains(where: { $0.property == Property.marginRight() }) &&
+           !title.attributes.styles.contains(where: { $0.property == Property.marginLeft() }) {
+            icon.attributes.add(styles: .init(.marginRight, value: "10px"))
+        }
+
+        var attributes = attributes
+        attributes.add(styles: .init(.display, value: "inline-flex"))
+        attributes.add(styles: .init(.alignItems, value: "center"))
+        return "<span\(attributes)>\(icon)\(title)</span>"
+    }
+}

--- a/Sources/Ignite/Elements/Label.swift
+++ b/Sources/Ignite/Elements/Label.swift
@@ -49,23 +49,23 @@ public struct Label: InlineElement {
         var title = title
 
         if !(title is String) {
-            title.attributes.add(classes: "mb-0")
+            title.attributes.append(classes: "mb-0")
         }
 
         var icon = icon
 
         if !(icon is String) {
-            icon.attributes.add(classes: "mb-0")
+            icon.attributes.append(classes: "mb-0")
         }
 
         if !icon.attributes.styles.contains(where: { $0.property == Property.marginRight() }) &&
            !title.attributes.styles.contains(where: { $0.property == Property.marginLeft() }) {
-            icon.attributes.add(styles: .init(.marginRight, value: "10px"))
+            icon.attributes.append(styles: .init(.marginRight, value: "10px"))
         }
 
         var attributes = attributes
-        attributes.add(styles: .init(.display, value: "inline-flex"))
-        attributes.add(styles: .init(.alignItems, value: "center"))
+        attributes.append(styles: .init(.display, value: "inline-flex"))
+        attributes.append(styles: .init(.alignItems, value: "center"))
         return "<span\(attributes)>\(icon)\(title)</span>"
     }
 }

--- a/Sources/Ignite/Elements/Label.swift
+++ b/Sources/Ignite/Elements/Label.swift
@@ -27,10 +27,10 @@ public struct Label: InlineElement {
     /// Creates a label with a string title and image icon.
     /// - Parameters:
     ///   - title: The text to display in the label.
-    ///   - name: The image to use as the label's icon.
-    public init(_ title: String, image name: String) {
+    ///   - path: The image to use as the label's icon.
+    public init(_ title: String, image path: String) {
         self.title = title
-        self.icon = Image(decorative: name)
+        self.icon = Image(path, description: title)
     }
 
     /// Creates a label with a string title and a built-in icon.
@@ -39,7 +39,7 @@ public struct Label: InlineElement {
     ///   - systemImage: An image name chosen from https://icons.getbootstrap.com
     public init(_ title: String, systemImage: String) {
         self.title = title
-        self.icon = Image(systemName: systemImage, description: "")
+        self.icon = Image(systemName: systemImage, description: title)
     }
 
     /// Creates a label with custom title and icon content.

--- a/Sources/Ignite/Elements/Label.swift
+++ b/Sources/Ignite/Elements/Label.swift
@@ -27,10 +27,19 @@ public struct Label: InlineElement {
     /// Creates a label with a string title and image icon.
     /// - Parameters:
     ///   - title: The text to display in the label.
-    ///   - image: The image to use as the label's icon.
-    public init(_ title: String, image: Image) {
+    ///   - name: The image to use as the label's icon.
+    public init(_ title: String, image name: String) {
         self.title = title
-        self.icon = image
+        self.icon = Image(decorative: name)
+    }
+
+    /// Creates a label with a string title and a built-in icon.
+    /// - Parameters:
+    ///   - title: The text to display in the label.
+    ///   - systemImage: An image name chosen from https://icons.getbootstrap.com
+    public init(_ title: String, systemImage: String) {
+        self.title = title
+        self.icon = Image(systemName: systemImage, description: "")
     }
 
     /// Creates a label with custom title and icon content.

--- a/Sources/Ignite/Framework/Property.swift
+++ b/Sources/Ignite/Framework/Property.swift
@@ -1012,4 +1012,8 @@ public enum Property: String, Sendable {
     /// Sets the zoom level of an element
     case zoom = "zoom"
 }
+
+extension Property {
+    func callAsFunction() -> String { rawValue }
+}
 // swiftlint:enable file_length type_body_length

--- a/Tests/IgniteTesting/Elements/FormFieldLabel.swift
+++ b/Tests/IgniteTesting/Elements/FormFieldLabel.swift
@@ -1,8 +1,8 @@
 //
-//  Label.swift
-//  Ignite
-//  https://www.github.com/twostraws/Ignite
-//  See LICENSE for license information.
+// FormFieldLabel.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
 //
 
 import Foundation
@@ -10,10 +10,10 @@ import Testing
 
 @testable import Ignite
 
-/// Tests for the `Label` element.
-@Suite("Label Tests")
+/// Tests for the `FormFieldLabel` element.
+@Suite("Form Field Label Tests")
 @MainActor
-class LabelTests: IgniteTestSuite {
+class FormFieldLabelTests: IgniteTestSuite {
     @Test("Basic Label")
     func basicLabel() async throws {
         let element = FormFieldLabel(text: "This is a text for label")

--- a/Tests/IgniteTesting/Elements/Label.swift
+++ b/Tests/IgniteTesting/Elements/Label.swift
@@ -21,7 +21,7 @@ class LabelTests: IgniteTestSuite {
 
         #expect(output == """
         <span style="display: inline-flex; align-items: center">\
-        <img src="/images/logo.png" alt="" class="mb-0" style="margin-right: 10px" />\
+        <img src="/images/logo.png" alt="Logo" class="mb-0" style="margin-right: 10px" />\
         Logo\
         </span>
         """)

--- a/Tests/IgniteTesting/Elements/Label.swift
+++ b/Tests/IgniteTesting/Elements/Label.swift
@@ -1,0 +1,29 @@
+//
+// Label.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+import Testing
+
+@testable import Ignite
+
+/// Tests for the `Label` element.
+@Suite("Label Tests")
+@MainActor
+class LabelTests: IgniteTestSuite {
+    @Test("Basic Label")
+    func basicLabel() async throws {
+        let element = Label("Logo", image: .init(decorative: "/images/logo.png"))
+        let output = element.render()
+
+        #expect(output == """
+        <span style="display: inline-flex; align-items: center">\
+        <img src="/images/logo.png" alt="" class="mb-0" style="margin-right: 10px" />\
+        Logo\
+        </span>
+        """)
+    }
+}

--- a/Tests/IgniteTesting/Elements/Label.swift
+++ b/Tests/IgniteTesting/Elements/Label.swift
@@ -16,7 +16,7 @@ import Testing
 class LabelTests: IgniteTestSuite {
     @Test("Basic Label")
     func basicLabel() async throws {
-        let element = Label("Logo", image: .init(decorative: "/images/logo.png"))
+        let element = Label("Logo", image: "/images/logo.png")
         let output = element.render()
 
         #expect(output == """


### PR DESCRIPTION
This PR addresses an issue raised in #735 by creating a SwiftUI-like `Label` type that easily allows users to put `Text` and `Image` side by side—particularly convenient for nav bars.