### PR TITLE
Allow users to determine the style of an article's tag links.

### DIFF
--- a/Sources/Ignite/Elements/ArticlePreview.swift
+++ b/Sources/Ignite/Elements/ArticlePreview.swift
@@ -73,7 +73,9 @@ public struct ArticlePreview: HTML {
 
             if let tagLinks {
                 Section {
-                    tagLinks
+                    ForEach(tagLinks) { link in
+                        link
+                    }
                 }
                 .style(.marginTop, "-5px")
             }


### PR DESCRIPTION
This PR allows users to determine the appearance of an article's tag links by updating the `tagLinks()` method from this:

```swift
 @InlineElementBuilder public func tagLinks() -> (some InlineElement)? {
```

to this:

```swift
  public func tagLinks(style: TagLinkStyle = .automatic) -> [Link]? {
```