### PR TITLE
Fix long-standing bugs in `frame()`.

### DIFF
--- a/Sources/Ignite/Elements/ZStack.swift
+++ b/Sources/Ignite/Elements/ZStack.swift
@@ -28,9 +28,9 @@ public struct ZStack: HTML {
     /// The child elements to be stacked.
     private var items: HTMLCollection
 
-    /// Creates a new ZStack with the specified alignment and content.
+    /// Creates a new `ZStack` with the specified alignment and content.
     /// - Parameters:
-    ///   - alignment: The point within the stack where elements should be aligned (default: .center).
+    ///   - alignment: The point within the stack where elements should be aligned. Defaults `.center`.
     ///   - items: A closure that returns the elements to be stacked.
     public init(alignment: Alignment = .center, @HTMLBuilder _ items: () -> some HTML) {
         self.items = HTMLCollection(items)
@@ -50,7 +50,7 @@ public struct ZStack: HTML {
                 .init(.zIndex, value: "\(index)")
             ])
 
-            elementAttributes.append(styles: alignment.flexAlignmentRules)
+            elementAttributes.append(styles: alignment.itemAlignmentRules)
             return item.attributes(elementAttributes)
         }
 
@@ -62,9 +62,9 @@ public struct ZStack: HTML {
     }
 }
 
-fileprivate extension Alignment {
-    /// Grid container rules for aligning content
-    var flexAlignmentRules: [InlineStyle] {
+private extension Alignment {
+    /// Alignment rules for the items of containers
+    var itemAlignmentRules: [InlineStyle] {
         switch (horizontal, vertical) {
         case (.leading, .top):      [.init(.alignSelf, value: "flex-start"), .init(.justifySelf, value: "flex-start")]
         case (.center, .top):       [.init(.alignSelf, value: "flex-start"), .init(.justifySelf, value: "center")]

--- a/Sources/Ignite/Modifiers/ContainerRelativeFrame.swift
+++ b/Sources/Ignite/Modifiers/ContainerRelativeFrame.swift
@@ -30,29 +30,10 @@ private extension HTML {
         return frameableContent
             .style(.display, "flex")
             .style(.flexDirection, "column")
-            .style(.position, "absolute")
             .style(.overflow, "hidden")
             .style(edgeAlignmentRules)
             .style(alignment.flexAlignmentRules)
             .style(.width, "100%")
             .style(.height, "100%")
-            .style(.position, "relative")
-    }
-}
-
-private extension Alignment {
-    /// Flex container rules for aligning content
-    var flexAlignmentRules: [InlineStyle] {
-        switch (horizontal, vertical) {
-        case (.leading, .top): [.init(.alignItems, value: "flex-start"), .init(.justifyContent, value: "flex-start")]
-        case (.center, .top): [.init(.alignItems, value: "center"), .init(.justifyContent, value: "flex-start")]
-        case (.trailing, .top): [.init(.alignItems, value: "flex-end"), .init(.justifyContent, value: "flex-start")]
-        case (.leading, .center): [.init(.alignItems, value: "flex-start"), .init(.justifyContent, value: "center")]
-        case (.center, .center): [.init(.alignItems, value: "center"), .init(.justifyContent, value: "center")]
-        case (.trailing, .center): [.init(.alignItems, value: "flex-end"), .init(.justifyContent, value: "center")]
-        case (.leading, .bottom): [.init(.alignItems, value: "flex-start"), .init(.justifyContent, value: "flex-end")]
-        case (.center, .bottom): [.init(.alignItems, value: "center"), .init(.justifyContent, value: "flex-end")]
-        case (.trailing, .bottom): [.init(.alignItems, value: "flex-end"), .init(.justifyContent, value: "flex-end")]
-        }
     }
 }

--- a/Sources/Ignite/Modifiers/Frame.swift
+++ b/Sources/Ignite/Modifiers/Frame.swift
@@ -15,7 +15,9 @@ public extension HTML {
     ///   - height: An exact height for this element
     ///   - minHeight: A minimum height for this element
     ///   - maxHeight: A maximum height for this element
-    ///   - alignment: How to align this element inside its frame. Defaults to `nil`.
+    ///   - alignment: How to align this element inside its frame. When `nil`, dimensions are applied directly 
+    ///     to the element. When specified, creates an invisible frame with the given dimensions
+    ///     and aligns the element within it according to the alignment value.
     /// - Returns: A modified copy of the element with frame constraints applied
     func frame(
         width: LengthUnit? = nil,
@@ -45,7 +47,9 @@ public extension HTML {
     ///   - height: An exact height for this element
     ///   - minHeight: A minimum height for this element
     ///   - maxHeight: A maximum height for this element
-    ///   - alignment: How to align this element inside its frame. Defaults to `nil`.
+    ///   - alignment: How to align this element inside its frame. When `nil`, dimensions are applied directly 
+    ///     to the element. When specified, creates an invisible frame with the given dimensions
+    ///     and aligns the element within it according to the alignment value.
     /// - Returns: A modified copy of the element with frame constraints applied
     func frame(
         width: Int? = nil,
@@ -84,7 +88,6 @@ public extension InlineElement {
     ///   - height: An exact height for this element
     ///   - minHeight: A minimum height for this element
     ///   - maxHeight: A maximum height for this element
-    ///   - alignment: How to align this element inside its frame. Defaults to `nil`.
     /// - Returns: A modified copy of the element with frame constraints applied
     func frame(
         width: LengthUnit? = nil,
@@ -92,8 +95,7 @@ public extension InlineElement {
         maxWidth: LengthUnit? = nil,
         height: LengthUnit? = nil,
         minHeight: LengthUnit? = nil,
-        maxHeight: LengthUnit? = nil,
-        alignment: Alignment? = nil
+        maxHeight: LengthUnit? = nil
     ) -> some InlineElement {
         AnyHTML(frameModifier(
             width: width,
@@ -101,8 +103,7 @@ public extension InlineElement {
             maxWidth: maxWidth,
             height: height,
             minHeight: minHeight,
-            maxHeight: maxHeight,
-            alignment: alignment))
+            maxHeight: maxHeight))
     }
 
     /// Creates a specific frame for this element, either using exact pixel values or
@@ -114,7 +115,6 @@ public extension InlineElement {
     ///   - height: An exact height for this element
     ///   - minHeight: A minimum height for this element
     ///   - maxHeight: A maximum height for this element
-    ///   - alignment: How to align this element inside its frame. Defaults to `nil`.
     /// - Returns: A modified copy of the element with frame constraints applied
     func frame(
         width: Int? = nil,
@@ -122,8 +122,7 @@ public extension InlineElement {
         maxWidth: Int? = nil,
         height: Int? = nil,
         minHeight: Int? = nil,
-        maxHeight: Int? = nil,
-        alignment: Alignment? = nil
+        maxHeight: Int? = nil
     ) -> some InlineElement {
         AnyHTML(frameModifier(
             width: width.map { .px($0) },
@@ -131,61 +130,7 @@ public extension InlineElement {
             maxWidth: maxWidth.map { .px($0) },
             height: height.map { .px($0) },
             minHeight: minHeight.map { .px($0) },
-            maxHeight: maxHeight.map { .px($0) },
-            alignment: alignment))
-    }
-
-    /// A convenience method for setting only the alignment.
-    /// - Parameter alignment: The desired alignment
-    /// - Returns: A modified element with the specified alignment
-    func frame(alignment: Alignment) -> some InlineElement {
-        AnyHTML(frameModifier(alignment: alignment))
-    }
-}
-
-/// Represents the different types of dimensional constraints that can be applied to an element.
-private enum Dimension {
-    /// The exact width, minimum width, or maximum width constraints
-    case width, minWidth, maxWidth
-    /// The exact height, minimum height, or maximum height constraints
-    case height, minHeight, maxHeight
-
-    /// The CSS property name for this dimension.
-    var cssProperty: Property {
-        switch self {
-        case .width: .width
-        case .minWidth: .minWidth
-        case .maxWidth: .maxWidth
-        case .height: .height
-        case .minHeight: .minHeight
-        case .maxHeight: .maxHeight
-        }
-    }
-
-    /// The Bootstrap class to use when the dimension should fill its container.
-    var bootstrapClass: String {
-        switch self {
-        case .width, .minWidth, .maxWidth: "w-100"
-        case .height, .minHeight, .maxHeight: "h-100"
-        }
-    }
-
-    /// The Bootstrap class to use when the dimension should fill the viewport.
-    var viewportClass: String {
-        switch self {
-        case .width, .maxWidth: "vw-100"
-        case .minWidth: "min-vw-100"
-        case .height, .maxHeight: "vh-100"
-        case .minHeight: "min-vh-100"
-        }
-    }
-
-    /// Whether this dimension requires flex alignment when using viewport sizing.
-    var needsFlexAlignment: Bool {
-        switch self {
-        case .width, .maxWidth, .height, .maxHeight: true
-        case .minWidth, .minHeight: false
-        }
+            maxHeight: maxHeight.map { .px($0) }))
     }
 }
 

--- a/Sources/Ignite/Types/Alignment.swift
+++ b/Sources/Ignite/Types/Alignment.swift
@@ -53,4 +53,19 @@ extension Alignment {
     var bootstrapClasses: [String] {
         [horizontal.flexAlignmentClass, vertical.flexAlignmentClass]
     }
+
+    /// Flex container rules for aligning content
+    var flexAlignmentRules: [InlineStyle] {
+        switch (horizontal, vertical) {
+        case (.leading, .top): [.init(.alignItems, value: "flex-start"), .init(.justifyContent, value: "flex-start")]
+        case (.center, .top): [.init(.alignItems, value: "center"), .init(.justifyContent, value: "flex-start")]
+        case (.trailing, .top): [.init(.alignItems, value: "flex-end"), .init(.justifyContent, value: "flex-start")]
+        case (.leading, .center): [.init(.alignItems, value: "flex-start"), .init(.justifyContent, value: "center")]
+        case (.center, .center): [.init(.alignItems, value: "center"), .init(.justifyContent, value: "center")]
+        case (.trailing, .center): [.init(.alignItems, value: "flex-end"), .init(.justifyContent, value: "center")]
+        case (.leading, .bottom): [.init(.alignItems, value: "flex-start"), .init(.justifyContent, value: "flex-end")]
+        case (.center, .bottom): [.init(.alignItems, value: "center"), .init(.justifyContent, value: "flex-end")]
+        case (.trailing, .bottom): [.init(.alignItems, value: "flex-end"), .init(.justifyContent, value: "flex-end")]
+        }
+    }
 }


### PR DESCRIPTION
A much, much better solution than what was proposed in #751 .

`Frame` has never been able to handle cases like this correctly:

```swift
Image("/images/interactions.png")
    .resizable()
    .frame(height: .px(250))
    .frame(width: .percent(100%), height: .px(550), alignment: .bottom)
```

This PR has reimplemented `Frame` to fix that issue, chiefly by making the `alignment` property—which is really a separate concern in HTML/CSS—optional.

When `alignment` is `nil`, `frame()` simply applies the specified dimensions to the modified element.

When `alignment` has a value, `frame()` wraps the modified element in a container with the specified dimensions and aligns it within that container accordingly. NB: Because `<div>` is a block element, this parameter is not available in the `InlineElement` variants of the modifier.

This implementation gives us simplicity when we need to set only a width or height, but power when we need a more robust positioning context—just like SwiftUI.

 