### PR TITLE
Fix incorrect access level for class modifier

### DIFF
--- a/Sources/Ignite/Modifiers/Attribute Modifiers/ClassModifier.swift
+++ b/Sources/Ignite/Modifiers/Attribute Modifiers/ClassModifier.swift
@@ -33,7 +33,7 @@ public extension InlineElement {
     }
 }
 
-extension HTML {
+public extension HTML {
     /// Adds multiple optional CSS classes to the element.
     /// - Parameter newClasses: Variable number of optional class names
     /// - Returns: The modified HTML element
@@ -50,7 +50,7 @@ extension HTML {
     }
 }
 
-extension InlineElement {
+public extension InlineElement {
     /// Adds multiple optional CSS classes to the element.
     /// - Parameter newClasses: Variable number of optional class names
     /// - Returns: The modified HTML element


### PR DESCRIPTION
The variadic `class` modifiers were not marked as public but they are very handy, so I marked them as public.