### PR TITLE
Make `EnvironmentValues` available in `prepare()`.

### DIFF
--- a/Sources/Ignite/Framework/Environment/DynamicEnvironmentValues.swift
+++ b/Sources/Ignite/Framework/Environment/DynamicEnvironmentValues.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// A type that stores global configuration and Layout settings for your site.
+/// A type that stores global configuration and layout settings for your site.
 ///
 /// Environment values are propagated through your site's view hierarchy and can be accessed
 /// using the `@Environment` property wrapper. For example:
@@ -18,7 +18,7 @@ import Foundation
 /// }
 /// ```
 @MainActor
-public struct EnvironmentValues {
+public struct DynamicEnvironmentValues {
     /// Provides access to the Markdown articles on this site.
     public var articles: ArticleLoader
 

--- a/Sources/Ignite/Framework/Environment/Environment.swift
+++ b/Sources/Ignite/Framework/Environment/Environment.swift
@@ -16,6 +16,9 @@
 /// ```
 @MainActor
 @propertyWrapper public struct Environment<Value> {
+    /// A type that stores global configuration and layout settings for your site.
+    public typealias EnvironmentValues = DynamicEnvironmentValues
+
     /// The key path to the desired environment value.
     private let keyPath: KeyPath<EnvironmentValues, Value>
 

--- a/Sources/Ignite/Framework/Environment/StaticEnvironmentValues.swift
+++ b/Sources/Ignite/Framework/Environment/StaticEnvironmentValues.swift
@@ -1,0 +1,60 @@
+//
+// StaticEnvironmentValues.swift
+// Ignite
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+
+/// A type that stores global site settings available to use before the site is published.
+@MainActor
+public struct StaticEnvironmentValues {
+    /// Provides access to the Markdown articles on this site.
+    public var articles: ArticleLoader
+
+    /// Configuration for RSS/Atom feed generation.
+    public var feedConfiguration: FeedConfiguration?
+
+    /// Available themes for the site, including light, dark, and any alternates.
+    public var themes: [any Theme] = []
+
+    /// Locates, loads, and decodes a JSON file in your Resources folder.
+    public var decode: DecodeAction
+
+    /// The site's metadata, such as name, description, and URL.
+    public let site: SiteMetadata
+
+    /// The author of the site
+    public let author: String
+
+    /// The language the site is published in
+    public let language: Language
+
+    /// The time zone used in date outputs.
+    public let timeZone: TimeZone?
+
+    /// The path to the favicon
+    public let favicon: URL?
+
+    /// Configuration for Bootstrap icons
+    public let builtInIconsEnabled: BootstrapOptions
+
+    init(sourceDirectory: URL, site: any Site, allContent: [Article]) {
+        self.decode = DecodeAction(sourceDirectory: sourceDirectory)
+        self.articles = ArticleLoader(content: allContent)
+        self.feedConfiguration = site.feedConfiguration
+        self.themes = site.allThemes
+        self.author = site.author
+        self.language = site.language
+        self.favicon = site.favicon
+        self.builtInIconsEnabled = site.builtInIconsEnabled
+        self.timeZone = site.timeZone
+
+        self.site = SiteMetadata(
+            name: site.name,
+            titleSuffix: site.titleSuffix,
+            description: site.description,
+            url: site.url)
+    }
+}

--- a/Sources/Ignite/Publishing/PublishingContext-Rendering.swift
+++ b/Sources/Ignite/Publishing/PublishingContext-Rendering.swift
@@ -24,7 +24,7 @@ extension PublishingContext {
             image: page.image
         )
 
-        let values = EnvironmentValues(
+        let values = DynamicEnvironmentValues(
             sourceDirectory: sourceDirectory,
             site: site,
             allContent: allContent,
@@ -52,7 +52,7 @@ extension PublishingContext {
             image: article.image.flatMap { URL(string: $0) }
         )
 
-        let values = EnvironmentValues(
+        let values = DynamicEnvironmentValues(
             sourceDirectory: sourceDirectory,
             site: site,
             allContent: allContent,
@@ -98,7 +98,7 @@ extension PublishingContext {
                 AllTagsCategory(articles: content(tagged: nil))
             }
 
-            let values = EnvironmentValues(
+            let values = DynamicEnvironmentValues(
                 sourceDirectory: sourceDirectory,
                 site: site,
                 allContent: allContent,

--- a/Sources/Ignite/Publishing/PublishingContext.swift
+++ b/Sources/Ignite/Publishing/PublishingContext.swift
@@ -59,7 +59,7 @@ final class PublishingContext {
     private(set) var errors = [PublishingError]()
 
     /// The current environment values for the application.
-    var environment = EnvironmentValues()
+    var environment = DynamicEnvironmentValues()
 
     /// All the Markdown content this user has inside their Content folder.
     private(set) var allContent = [Article]()
@@ -97,6 +97,8 @@ final class PublishingContext {
         fontsDirectory = sourceDirectory.appending(path: "Fonts")
         contentDirectory = sourceDirectory.appending(path: "Content")
         includesDirectory = sourceDirectory.appending(path: "Includes")
+
+        try parseContent()
     }
 
     /// Creates and sets the shared instance of `PublishingContext`
@@ -187,7 +189,6 @@ final class PublishingContext {
 
     /// Performs all steps required to publish a site.
     func publish() async throws {
-        try parseContent()
         clearBuildFolder()
         await generateContent()
         copyResources()
@@ -300,7 +301,7 @@ final class PublishingContext {
     ///   - environment: The new environment values to use
     ///   - operation: A closure that executes with the temporary environment
     /// - Returns: The value returned by the operation
-    func withEnvironment<T>(_ environment: EnvironmentValues, operation: () -> T) -> T {
+    func withEnvironment<T>(_ environment: DynamicEnvironmentValues, operation: () -> T) -> T {
         let previous = self.environment
         self.environment = environment
         defer { self.environment = previous }

--- a/Tests/IgniteTesting/Elements/HTMLDocument.swift
+++ b/Tests/IgniteTesting/Elements/HTMLDocument.swift
@@ -48,7 +48,7 @@ class HTMLDocumentTests: IgniteTestSuite {
         site.language = language
 
         /// Create an environment and initialize it with the set language. 
-        let values = EnvironmentValues(
+        let values = DynamicEnvironmentValues(
             sourceDirectory: publishingContext.sourceDirectory,
             site: site,
             allContent: publishingContext.allContent,


### PR DESCRIPTION
This PR gives users access to a subset of available environment values—like a site's articles—in `Site`'s `prepare()` method.