### PR TITLE
Fix for Article.type always returning an empty string.

### DIFF
--- a/Sources/Ignite/Framework/Article.swift
+++ b/Sources/Ignite/Framework/Article.swift
@@ -158,7 +158,7 @@ public struct Article {
         self.path = metadata["path"] as? String ?? deployPath
 
         // Save the first subfolder in the path as the article's type
-        let pathParts = path.split(separator: "/") // removes empty
+        let pathParts = path.split(separator: "/").map { String($0) } // removes empty
         if pathParts.count > 1 { // no type if not in subdirectory
             metadata["type"] = pathParts[0]
         }


### PR DESCRIPTION
Currently the `Article type` variable always returns an empty string. It uses the following code to extract the `type` string from the `Article`'s metadata:

```
if let type = metadata["type"] {
            type as? String ?? ""
        } else {
            fatalError("""
            Unable to retrieve type for article '\(title)'. \
            Please file a bug report on the Ignite project.
            """)
        }

```

However, the cast `type as? String ?? ""` will always fail and return the default empty string. The `metadata["type"]` is stored in `Article`'s `init()` using the following code:

```
// Save the first subfolder in the path as the article's type
        let pathParts = path.split(separator: "/") // removes empty
        if pathParts.count > 1 { // no type if not in subdirectory
            metadata["type"] = pathParts[0]
        }
```

The problem here is `path.split(separator: "/")` returns a `[Substring]` not a `[String]`, so `type` is stored as a `Substring` not a `String`, meaning the cast `type as? String ?? ""` will always return an empty string.

A side effect of this is the `ArticleLoader` func `typed(_ type: String)` will always return an empty `[Article]`. This is how I noticed the bug :)

The fix takes the result of `path.split(separator: "/")` and maps it to a `[String]` to ensure the `metadata["type"]` is stored as a `String`.
