### PR TITLE
Perform Document rendering in reversed order to defer Head rendering

### DIFF
--- a/Sources/Ignite/Elements/Document.swift
+++ b/Sources/Ignite/Elements/Document.swift
@@ -27,8 +27,11 @@ public struct Document: MarkupElement {
         attributes.append(customAttributes: .init(name: "lang", value: language.rawValue))
         var output = "<!doctype html>"
         output += "<html\(attributes)>"
-        output += head.markupString()
-        output += body.markupString()
+        let bodyMarkup = body.markup()
+        // Deferred head rendering to accommodate for context updates during body rendering
+        let headMarkup = head.markup()
+        output += headMarkup.string
+        output += bodyMarkup.string
         output += "</html>"
         return Markup(output)
     }


### PR DESCRIPTION
While tinkering with Ignite I noticed one bug with regards to CodeBlock rendering. It is supposed to automatically pick up Code language and highlight it when using Ignition DSL. This was not working though for the first page with CodeBlock element.

After some debugging I have noticed that we update `PublishingContext` with language of the code block and based on that correct header is to be rendered. Unfortunatelly at that time `Head` of that page is already rendered, hence this update to the context is not reflected.

I have considered different approaches:
- Leveraging that we expect `Document` to have `Head` element - getting its index (though I believe it should always be 0?) and deferring its rendering phase "manually"
  - More explicit, yet too much hassle with no real gain IMO
- Reversing render phase, then reversing again to construct content
  - ✅ Chosen solution - because of its simplicity
- Spliting render into prep and render phase (eg add pre-render phase)
  - Might be nicest solutjon, yet super complex and do not see a reason for such big refactor (targeting single case)
- Remove automatic code highlight insertion into `PublishingContext`
  - Maybe it should just never be there and users should be forced to correctly reference languages for code highlight in `Site` definition?

Attaching video with issue reproduced:

https://github.com/user-attachments/assets/832c5a24-5201-4a6a-ba41-3bb8487bb4da

Issue can be reproduced by having site with homePage having such body:
```swift
var body: some HTML {
    Text("Hello world!")
        .font(.title1)
    ForEach(articles.all) { article in
        Link(article.title, target: article)
    }
    
    CodeBlock(.swift) {
        """
        struct Test {
            var test = "Hello World"
        }
        """
    }
}
```

Alternatively it can be reproduced with https://github.com/twostraws/IgniteSamples when commenting out `syntaxHighlighterConfiguration` in `Site` definition.