### PR TITLE
Fix custom font inline style

### DIFF
--- a/Sources/Ignite/Modifiers/FontModifier.swift
+++ b/Sources/Ignite/Modifiers/FontModifier.swift
@@ -12,7 +12,7 @@ private func fontModifier(_ font: Font, content: any HTML) -> any HTML {
         styles.append(.init(.fontWeight, value: font.weight.rawValue.formatted()))
 
         if let name = font.name, !name.isEmpty {
-            styles.append(.init(.fontFamily, value: "\"\(name)\""))
+            styles.append(.init(.fontFamily, value: name))
         }
 
         if let size = font.size {

--- a/Sources/Ignite/Modifiers/FontModifier.swift
+++ b/Sources/Ignite/Modifiers/FontModifier.swift
@@ -147,7 +147,7 @@ public extension StyledHTML {
         }
 
         if let name = font.name, !name.isEmpty {
-            styles.append(.init(.fontFamily, value: "\"\(name)\""))
+            styles.append(.init(.fontFamily, value: name))
         }
 
         if let size = font.size {

--- a/Sources/Ignite/Modifiers/FontModifier.swift
+++ b/Sources/Ignite/Modifiers/FontModifier.swift
@@ -38,7 +38,7 @@ private func fontModifier(_ font: Font, content: any HTML) -> any HTML {
         styles.append(.init(.fontWeight, value: String(font.weight.rawValue)))
 
         if let name = font.name, !name.isEmpty {
-            styles.append(.init(.fontFamily, value: "\"\(name)\""))
+            styles.append(.init(.fontFamily, value: name))
         }
 
         if let size = font.size {

--- a/Sources/Ignite/Modifiers/FontModifier.swift
+++ b/Sources/Ignite/Modifiers/FontModifier.swift
@@ -63,7 +63,7 @@ private func fontModifier(_ font: Font, content: any InlineElement) -> any Inlin
     styles.append(.init(.fontWeight, value: font.weight.rawValue.formatted()))
 
     if let name = font.name, !name.isEmpty {
-        styles.append(.init(.fontFamily, value: "\"\(name)\""))
+        styles.append(.init(.fontFamily, value: name))
     }
 
     if let size = font.size {

--- a/Tests/IgniteTesting/Modifiers/FontModifier.swift
+++ b/Tests/IgniteTesting/Modifiers/FontModifier.swift
@@ -31,7 +31,7 @@ struct FontModifierTests {
         let output = element.markupString()
 
         #expect(output == """
-        <p><span style="font-weight: 400; font-family: "Arial"; font-size: 16px">Sample text</span></p>
+        <p><span style="font-weight: 400; font-family: Arial; font-size: 16px">Sample text</span></p>
         """)
     }
 
@@ -45,7 +45,7 @@ struct FontModifierTests {
         let output = element.markupString()
 
         #expect(output == """
-        <p><span style="font-weight: 700; font-family: "Arial"; font-size: 16px">Sample text</span></p>
+        <p><span style="font-weight: 700; font-family: Arial; font-size: 16px">Sample text</span></p>
         """)
     }
 
@@ -59,7 +59,7 @@ struct FontModifierTests {
         let output = element.markupString()
 
         #expect(output == """
-        <p><span style="font-weight: 400; font-family: "Arial"; font-size: 1.5em">Sample text</span></p>
+        <p><span style="font-weight: 400; font-family: Arial; font-size: 1.5em">Sample text</span></p>
         """)
     }
 
@@ -73,7 +73,7 @@ struct FontModifierTests {
         let output = element.markupString()
 
         #expect(output == """
-        <p><span style="font-weight: 400; font-family: "Times New Roman"; font-size: 16px">Sample text</span></p>
+        <p><span style="font-weight: 400; font-family: Times New Roman; font-size: 16px">Sample text</span></p>
         """)
     }
 


### PR DESCRIPTION
While working with 0.6 beta I have noticed that custom fonts are not applying. It seems to be caused by redundant quotation  marks.

Here is how change manifests in html:
<img width="286" alt="Screenshot 2025-04-27 at 21 22 35" src="https://github.com/user-attachments/assets/65f7617e-b066-4783-ac30-9cab54e72fda" />

After the fix fonts are correctly applied.

