### PR TITLE
Fix improper color opacity when using double

### DIFF
--- a/Sources/Ignite/Framework/Color.swift
+++ b/Sources/Ignite/Framework/Color.swift
@@ -541,7 +541,7 @@ public struct Color: CustomStringConvertible, Equatable, Hashable, Sendable {
         let intRed = Int(red * 255)
         let intGreen = Int(green * 255)
         let intBlue = Int(blue * 255)
-        let intOpacity = Int(opacity * 255)
+        let intOpacity = Int(opacity * 100)
 
         self.init(red: intRed, green: intGreen, blue: intBlue, opacity: intOpacity%)
     }
@@ -554,7 +554,7 @@ public struct Color: CustomStringConvertible, Equatable, Hashable, Sendable {
     ///   (transparent) through to 1 (opaque).
     public init(white: Double, opacity: Double = 1) {
         let intWhite = Int(white * 255)
-        let intOpacity = Int(opacity * 255)
+        let intOpacity = Int(opacity * 100)
 
         self.init(red: intWhite, green: intWhite, blue: intWhite, opacity: intOpacity%)
     }

--- a/Tests/IgniteTesting/Types/Color.swift
+++ b/Tests/IgniteTesting/Types/Color.swift
@@ -50,4 +50,16 @@ struct ColorTypeTests {
 
         #expect(color.description == "rgb(\(red) \(blue) \(green) / \(opacity.roundedValue)%)")
     }
+    
+    @Test("Double to Int Conversion in init(red:green:blue:opacity:)")
+    func rbgaInitWithDouble() {
+        let color = Color(red: 1.0, green: 1.0, blue: 1.0, opacity: 1.0)
+        #expect(color.description == "rgb(255 255 255 / 100%)")
+    }
+    
+    @Test("Double to Int Conversion in init(white:opacity:)")
+    func whiteAndOpacityInitWithDouble() {
+        let color = Color(white: 1.0, opacity: 1.0)
+        #expect(color.description == "rgb(255 255 255 / 100%)")
+    }
 }


### PR DESCRIPTION
Initialisers with Double converts opacity to 0-255 value which is incorrect.
Updated initialisers to use 0-100 % values instead.