### PR TITLE
Fix Missing Publishing Context HTTP Error

### DIFF
--- a/Sources/Ignite/Framework/Environment/EnvironmentValues.swift
+++ b/Sources/Ignite/Framework/Environment/EnvironmentValues.swift
@@ -105,7 +105,8 @@ public struct EnvironmentValues {
         site: any Site,
         allContent: [Article],
         pageMetadata: PageMetadata,
-        pageContent: any LayoutContent
+        pageContent: any LayoutContent,
+        httpError: HTTPError = EmptyHTTPError()
     ) {
         self.decode = DecodeAction(sourceDirectory: sourceDirectory)
         self.articles = ArticleLoader(content: allContent)
@@ -117,6 +118,7 @@ public struct EnvironmentValues {
         self.builtInIconsEnabled = site.builtInIconsEnabled
         self.timeZone = site.timeZone
         self.page = pageMetadata
+        self.httpError = httpError
 
         self.site = SiteMetadata(
             name: site.name,

--- a/Sources/Ignite/Publishing/PublishingContext-Rendering.swift
+++ b/Sources/Ignite/Publishing/PublishingContext-Rendering.swift
@@ -138,8 +138,6 @@ extension PublishingContext {
         if site.errorPage is EmptyErrorPage { return }
 
         for error in [PageNotFoundError()] {
-            environment.httpError = error
-
             let metadata = PageMetadata(
                 title: site.errorPage.title,
                 description: site.errorPage.description,
@@ -151,7 +149,9 @@ extension PublishingContext {
                 site: site,
                 allContent: allContent,
                 pageMetadata: metadata,
-                pageContent: site.errorPage)
+                pageContent: site.errorPage,
+                httpError: error
+            )
 
             let outputString = withEnvironment(values) {
                 site.errorPage.layout.body.markupString()

--- a/Tests/IgniteTesting/Publishing/Site.swift
+++ b/Tests/IgniteTesting/Publishing/Site.swift
@@ -122,7 +122,11 @@ struct SiteTests {
 
     @Test("Site published with a custom ErrorPage and custom content")
     func publishingWithCustomErrorPageAndContent() async throws {
-        let errorPage = TestErrorPage(title: "A different title", description: "A different description")
+        let expectedError = PageNotFoundError()
+
+        let errorPage = TestErrorPage(title: "A different title", description: "A different description") { error in
+            #expect(error.statusCode == expectedError.statusCode)
+        }
         let site = TestSiteWithErrorPage(errorPage: errorPage)
         var publisher = TestSitePublisher(site: site)
 

--- a/Tests/IgniteTesting/TestWebsitePackage/Sources/TestErrorPage.swift
+++ b/Tests/IgniteTesting/TestWebsitePackage/Sources/TestErrorPage.swift
@@ -27,7 +27,6 @@ struct TestErrorPage: ErrorPage {
 
     var body: some HTML {
         ErrorChecker { errorChecker(error) }
-        EmptyHTML()
     }
 
     struct ErrorChecker: HTML {

--- a/Tests/IgniteTesting/TestWebsitePackage/Sources/TestErrorPage.swift
+++ b/Tests/IgniteTesting/TestWebsitePackage/Sources/TestErrorPage.swift
@@ -13,7 +13,30 @@ struct TestErrorPage: ErrorPage {
     var title: String = "Test Error Page"
     var description: String = "Test Error Page Description"
 
+    let errorChecker: (HTTPError) -> Void
+
+    init(
+        title: String = "Test Error Page",
+        description: String = "Test Error Page Description",
+        errorChecker: @escaping (HTTPError) -> Void = { _ in }
+    ) {
+        self.title = title
+        self.description = description
+        self.errorChecker = errorChecker
+    }
+
     var body: some HTML {
+        ErrorChecker { errorChecker(error) }
         EmptyHTML()
+    }
+
+    struct ErrorChecker: HTML {
+        init(handler: @escaping () -> Void) {
+            handler()
+        }
+
+        var body: some HTML {
+            EmptyHTML()
+        }
     }
 }


### PR DESCRIPTION
We actually weren’t passing the relevant HTTP errors to `ErrorPage`s (either we never did, or it broke at some point without anyone noticing). The existing tests only checked for static strings, so they didn’t catch that the actual error instances weren’t being passed around correctly.

That’s now fixed, and the tests have been updated to properly check for this going forward.

