### PR TITLE
Fix the standard remote CSS that's being called

### DIFF
--- a/Sources/Ignite/Elements/Head.swift
+++ b/Sources/Ignite/Elements/Head.swift
@@ -93,7 +93,7 @@ public struct Head: MarkupElement {
         if site.useDefaultBootstrapURLs == .localBootstrap {
             MetaLink.standardCSS
         } else if site.useDefaultBootstrapURLs == .remoteBootstrap {
-            MetaLink.remoteIconCSS
+            MetaLink.standardRemoteCSS
         }
 
         if context.hasSyntaxHighlighters, site.allHighlighterThemes.isEmpty == false {


### PR DESCRIPTION
The remoteIconCss is also being called below
https://github.com/twostraws/Ignite/blob/c78ca96069732beef25feaab481d8cb2642e5aaa/Sources/Ignite/Elements/Head.swift#L106-L107

The .remoteBootstrap option may not be handled correctly in other places, so this is not intended to be a a full fix, but more as a step in the right direction