### PR TITLE
Use Reserved Domains

### DIFF
--- a/Tests/IgniteTesting/TestSubsite.swift
+++ b/Tests/IgniteTesting/TestSubsite.swift
@@ -11,7 +11,7 @@ import Ignite
 struct TestSubsite: Site {
     var name = "My Test Subsite"
     var titleSuffix = " - My Test Subsite"
-    var url = URL(static: "https://www.yoursite.com/subsite")
+    var url = URL(static: "https://www.example.com/subsite")
 
     var builtInIconsEnabled: BootstrapOptions = .localBootstrap
 

--- a/Tests/IgniteTesting/TestWebsitePackage/Sources/TestSite.swift
+++ b/Tests/IgniteTesting/TestWebsitePackage/Sources/TestSite.swift
@@ -12,7 +12,7 @@ import Ignite
 struct TestSite: Site {
     var name = "My Test Site"
     var titleSuffix = " - My Test Site"
-    var url = URL(static: "https://www.yoursite.com")
+    var url = URL(static: "https://www.example.com")
     var timeZone: TimeZone?
     var language: Language = .english
 

--- a/Tests/IgniteTesting/TestWebsitePackage/Sources/TestSiteWithErrorPage.swift
+++ b/Tests/IgniteTesting/TestWebsitePackage/Sources/TestSiteWithErrorPage.swift
@@ -12,7 +12,7 @@ import Ignite
 struct TestSiteWithErrorPage: Site {
     var name = "My Error Page Test Site"
     var titleSuffix = " - My Test Site"
-    var url = URL(static: "https://www.yoursite.com")
+    var url = URL(static: "https://www.example.com")
     var timeZone: TimeZone?
     var language: Language = .english
 


### PR DESCRIPTION
`example.com` is a reserved domain([rfc2606][]) by the IANA, and is recommended to use for documentation and examples([rfc6761][]).

I think it would be better to replace the current domain that's descriptive but privately owned, to a domain that's officially reserved for documentation purpose.

# Alternatives Considered

While it's possible to add a subdomain like `yoursite.example.com`, but considering `example.com` status as an official reserved domain and used though out the industry and is also used with in the Ignite project for documentation and tests, I think the using the standard `www.example.com` would be enough for most people to indicate it's use as an placeholder.

[rfc2606]: https://www.rfc-editor.org/rfc/rfc2606.html
[rfc6761]: https://www.rfc-editor.org/rfc/rfc6761.html