### PR TITLE
Adds more detail to doc comment for Image `init(_, description:)`

### DIFF
--- a/Sources/Ignite/Elements/Image.swift
+++ b/Sources/Ignite/Elements/Image.swift
@@ -32,8 +32,10 @@ public struct Image: InlineElement, LazyLoadable {
     /// Creates a new `Image` instance from the specified path. For an image contained
     /// in your site's assets, this should be specified relative to the root of your
     /// site, e.g. /images/dog.jpg.
+    /// Append `~dark` to the end of filenames for a dark mode version of the image. (`cool-image.svg` and `cool-image~dark.svg`)
+    /// Append `@2x` to the end of filenames to supply a higher resoloution version fo the image (`cool-image.png` and `cool-image@2x.png`)
     /// - Parameters:
-    ///   - name: The filename of your image relative to the root of your site.
+    ///   - path: The filename of your image relative to the root of your site.
     ///   e.g. /images/welcome.jpg.
     ///   - description: An description of your image suitable for screen readers.
     public init(_ path: String, description: String? = nil) {


### PR DESCRIPTION
This adds info on now to supply dark mode and 2x variants for images. For folks that do not spend much time building web pages it was not clear until poking around in the code how to set things up so that an image varies based on light versus dark mode. This aims to make it a bit easier for users to know what to do.

It also updates the first parameter name to match the signature.