### PR TITLE
Add explicit check for importing remote Bootstrap JS

### DIFF
--- a/Sources/Ignite/Elements/Body.swift
+++ b/Sources/Ignite/Elements/Body.swift
@@ -45,6 +45,7 @@ public struct Body: MarkupElement {
         if publishingContext.site.useDefaultBootstrapURLs == .localBootstrap {
             output += Script(file: "/js/bootstrap.bundle.min.js").markup()
         } else if
+            publishingContext.site.useDefaultBootstrapURLs == .remoteBootstrap,
             let url = URL(string: "https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js") {
             output += Script(file: url)
                 .customAttribute(


### PR DESCRIPTION
G'day Paul! Hope you've been well since try! Swift this year! 👋

I'm in the middle of migrating my blog away from WordPress (at long long last) and I'm looking at redoing the whole lot on Ignite! The documentation and the examples have made it incredibly easy to get started. 🤩

That being said, in typical developer fashion, I'd like to be able to start with an absolutely clean slate so I can specify my own CSS and JS from scratch. I was looking at disabling Bootstrap entirely, and I noticed that even if I set `useDefaultBootstrapURLs` to `.none`, it would still remotely import the Bootstrap JS file, which might not be the intended logic here.

Here's a quick PR for adding an explicit check, which I've confirmed already works correctly. 

Meanwhile, I'm still looking into if there's already  a way to do this, but I'd also like to disable `ignite-core.min.css` so I can implement my own CSS reset logic. I'll look into that for a separate PR.

Hope this helps! Thanks so much!