### PR TITLE
Add type attribute to Script to be used in HTML head.

### DIFF
--- a/Sources/Ignite/Elements/Script.swift
+++ b/Sources/Ignite/Elements/Script.swift
@@ -61,3 +61,15 @@ public struct Script: HTML, HeadElement {
         }
     }
 }
+
+public extension Script {
+    /// Adds a type attribute to the element.
+    /// - Parameters:
+    ///   - value: The value of the type attribute
+    /// - Returns: The modified `HTML` element
+    func type(value: String) -> Self {
+        var copy = self
+        copy.attributes.append(customAttributes: .init(name: "type", value: value))
+        return copy
+    }
+}

--- a/Tests/IgniteTesting/Elements/Script.swift
+++ b/Tests/IgniteTesting/Elements/Script.swift
@@ -13,49 +13,59 @@ import Testing
 @Suite("Script Tests")
 @MainActor class ScriptTests: IgniteTestSuite {
     static let sites: [any Site] = [TestSite(), TestSubsite()]
-
+    
     @Test("Code", arguments: await Self.sites)
     func code(for site: any Site) async throws {
         try PublishingContext.initialize(for: site, from: #filePath)
-
+        
         let element = Script(code: "javascript code")
         let output = element.markupString()
-
+        
         #expect(output == "<script>javascript code</script>")
     }
-
+    
     @Test("Local File", arguments: ["/code.js"], await Self.sites)
     func file(scriptFile: String, site: any Site) async throws {
         try PublishingContext.initialize(for: site, from: #filePath)
-
+        
         let element = Script(file: scriptFile)
         let output = element.markupString()
-
+        
         let expectedPath = PublishingContext.shared.path(for: URL(string: scriptFile)!)
         #expect(output == "<script src=\"\(expectedPath)\"></script>")
     }
-
+    
     @Test("Remote File", arguments: ["https://example.com"], await Self.sites)
     func file(remoteScript: String, site: any Site) async throws {
         try PublishingContext.initialize(for: site, from: #filePath)
-
+        
         let element = Script(file: remoteScript)
         let output = element.markupString()
-
+        
         let expectedPath = PublishingContext.shared.path(for: URL(string: remoteScript)!)
         #expect(output == "<script src=\"\(expectedPath)\"></script>")
     }
-
+    
     @Test("Attributes", arguments: ["/code.js"], await Self.sites)
     func attributes(scriptFile: String, site: any Site) async throws {
         try PublishingContext.initialize(for: site, from: #filePath)
-
+        
         let element = Script(file: scriptFile)
             .data("key", "value")
             .customAttribute(name: "custom", value: "part")
         let output = element.markupString()
-
+        
         let expectedPath = PublishingContext.shared.path(for: URL(string: scriptFile)!)
         #expect(output == "<script custom=\"part\" src=\"\(expectedPath)\" data-key=\"value\"></script>")
+    }
+    
+    @Test("TypeAttribute", arguments: await Self.sites)
+    func typeAttribute(for site: any Site) async throws {
+        try PublishingContext.initialize(for: site, from: #filePath)
+        
+        let element = Script(code: "javascript code").type(value: "someType")
+        let output = element.markupString()
+        
+        #expect(output == "<script type=\"someType\">javascript code</script>")
     }
 }


### PR DESCRIPTION
Currently, there is no way to specify a `type` attribute for the `Script` header element.

I want to add _JSON-LD_ to my site and the recommended way is to add it in the `Script` element by specifying the the `type` attribute `application/ld+json`.

This pull request might not be the best way to implement it, but at least it provides a workaround.