### PR TITLE
Feature request: Add `hoverEffect(_:)` support for `InlineElement`

### DIFF
--- a/Sources/Ignite/Modifiers/HoverEffect.swift
+++ b/Sources/Ignite/Modifiers/HoverEffect.swift
@@ -10,7 +10,7 @@ public extension HTML {
     /// - Parameter effect: A closure that returns the effect to be applied.
     ///   The argument acts as a placeholder representing this page element.
     /// - Returns: A modified copy of the element with hover effect applied
-    func hoverEffect(_ effect: @escaping (EmptHTMLyHoverEffect) -> some HTML) -> some HTML {
+    func hoverEffect(_ effect: @escaping (EmptyHTMLHoverEffect) -> some HTML) -> some HTML {
         self.hoverEffectModifier(effect)
     }
 }
@@ -18,11 +18,11 @@ public extension HTML {
 private extension HTML {
     // An abstraction of the implementation details for consistent reuse across protocol extensions.
     func hoverEffectModifier(
-        _ effect: @escaping (EmptHTMLyHoverEffect) -> some HTML
+        _ effect: @escaping (EmptyHTMLHoverEffect) -> some HTML
     ) -> some HTML {
         self.onHover { isHovering in
             if isHovering {
-                let effectElement = effect(EmptHTMLyHoverEffect())
+                let effectElement = effect(EmptyHTMLHoverEffect())
                 let effectAttributes = effectElement.attributes
                 ApplyHoverEffects(styles: effectAttributes.styles)
             } else {
@@ -33,7 +33,7 @@ private extension HTML {
 }
 
 /// An empty hover effect type to which styles can be added
-public struct EmptHTMLyHoverEffect: HTML {
+public struct EmptyHTMLHoverEffect: HTML {
     /// The content and behavior of this HTML.
     public var body: some HTML { self }
 


### PR DESCRIPTION
Due to commit eb9136db2ddfa6488caef1ee1bea2d5e2575b1a in #142, `hoverEffect(_:)` can no longer be called on the current `InlineElement` due to a missing protocol conformance.

This pull request restores support for `hoverEffect(_:)` on `InlineElement`.