### PR TITLE
Add Codaglot showcase to the list of web sites built with Ignite

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ That will launch a local web server you should use to preview your site, and als
 | [try! Swift Tokyo](https://tryswift.jp/en/) | [GitHub](https://github.com/tryswift/try-swift-tokyo) |
 | [Tomo Codes](https://tomo.codes) | [GitHub](https://github.com/TomaszLizer/TomoCodes) |
 | [Ryan Token](https://www.ryantoken.com) | [GitHub](https://github.com/r-token/ryantoken.com-v4-ignite) |
+| [Codaglot](https://codaglot.skjorn.name) | [GitHub](https://github.com/skjorn/codaglot-showcase) |
 
 
 ## Contributing


### PR DESCRIPTION
Hi!

I built a learning web site for the Kotlin programming language recently, using Ignite. I thought it could be an interesting showcase, as I had to customize certain things to a large extent.

Advanced customization includes:
- Full visual restyle
- Markdown processing before rendering pages
- Post-processing of rendered pages
- Custom article ordering

Thanks for the tool! It saved me quite some time.