### PR TITLE
Speculative fix for CI test failure: write atomically (and always clean)

### DIFF
--- a/Tests/IgniteTesting/Publishing/Site.swift
+++ b/Tests/IgniteTesting/Publishing/Site.swift
@@ -36,15 +36,16 @@ struct SiteTests {
 
         # Story with invalid lastModified
         """
+        defer {
+            try? package.clearBuildFolderAndTestContent()
+        }
 
-        try markdownContent.write(to: markdownFileURL, atomically: false, encoding: .utf8)
+        try markdownContent.write(to: markdownFileURL, atomically: true, encoding: .utf8)
 
         var site = TestSitePublisher()
         try await site.publish()
 
         #expect(package.checkIndexFileExists())
-
-        try package.clearBuildFolderAndTestContent()
     }
 
     @Test("Retrieving typed content")


### PR DESCRIPTION
For CI test failure reported in #858 and #861 

This fix is a guess; I'm unable to replicate the failure locally.
- Error is `The file “story-with-invalid-lastModified.md” doesn’t exist`
- I assume this is b/c check happens before the file-write is visible. (Although even non-atomic write should result in existing file?)

Also use defer to always clean (avoid false positive from prior file)