### PR TITLE
Set data-light-theme and data-dark-theme on html element

### DIFF
--- a/Sources/Ignite/Elements/PlainDocument.swift
+++ b/Sources/Ignite/Elements/PlainDocument.swift
@@ -30,6 +30,14 @@ public struct PlainDocument: Document {
         var attributes = attributes
         attributes.append(customAttributes: .init(name: "lang", value: language.rawValue))
 
+        let site = PublishingContext.shared.site
+        if let lightTheme = site.lightTheme {
+            attributes.append(customAttributes: .init(name: "data-light-theme", value: lightTheme.cssID))
+        }
+        if let darkTheme = site.darkTheme {
+            attributes.append(customAttributes: .init(name: "data-dark-theme", value: darkTheme.cssID))
+        }
+
         let bodyMarkup = body.markup()
         // Deferred head rendering to accommodate for context updates during body rendering
         let headMarkup = head.markup()

--- a/Tests/IgniteTesting/Elements/HTMLDocument.swift
+++ b/Tests/IgniteTesting/Elements/HTMLDocument.swift
@@ -40,6 +40,30 @@ class HTMLDocumentTests: IgniteTestSuite {
         #expect(language == "en")
     }
 
+    @Test("html tag includes data-light-theme attribute matching site light theme cssID")
+    func html_includes_data_light_theme_attribute() throws {
+        let sut = PlainDocument(head: Head(), body: Body())
+        let output = sut.markupString()
+
+        let lightTheme = try #require(output.htmlTagWithCloseTag("html")?.attributes
+            .htmlAttribute(named: "data-light-theme")
+        )
+
+        #expect(lightTheme == "light")
+    }
+
+    @Test("html tag includes data-dark-theme attribute matching site dark theme cssID")
+    func html_includes_data_dark_theme_attribute() throws {
+        let sut = PlainDocument(head: Head(), body: Body())
+        let output = sut.markupString()
+
+        let darkTheme = try #require(output.htmlTagWithCloseTag("html")?.attributes
+            .htmlAttribute(named: "data-dark-theme")
+        )
+
+        #expect(darkTheme == "dark")
+    }
+
     @Test("lang attribute is taken from language property", arguments: Language.allCases)
     func language_property_determines_lang_attribute(_ language: Language) throws {
 


### PR DESCRIPTION
## Summary

- **Fixes custom theme dark mode switching** by setting `data-light-theme` and `data-dark-theme` attributes on the `<html>` element in `PlainDocument.markup()`
- The existing theme-switching JavaScript reads these attributes to determine which CSS selectors to activate, but they were never set — causing custom themes to fall back to `"light"`/`"dark"` which don't match custom theme CSS selectors like `[data-bs-theme="my-theme-light"]`
- Adds two tests verifying the attributes are present with correct cssIDs

## Test plan

- [x] New tests in `HTMLDocumentTests` verify `data-light-theme` and `data-dark-theme` attributes are set on `<html>`
- [x] Full test suite passes (1075 tests, 0 failures)
- [ ] Verify with a site using custom themes that dark mode switching works without a JS workaround