### PR TITLE
Fix XML escaping in RSS feed generator

### DIFF
--- a/Sources/Ignite/Publishing/FeedGenerator.swift
+++ b/Sources/Ignite/Publishing/FeedGenerator.swift
@@ -17,6 +17,15 @@ struct FeedGenerator {
         self.content = content
     }
 
+    private func xmlEscape(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&apos;")
+    }
+
     func generateFeed() -> String {
         let contentXML = generateContentXML()
         var result = generateRSSHeader()
@@ -25,7 +34,7 @@ struct FeedGenerator {
             result += """
             <image>\
             <url>\(image.url)</url>\
-            <title>\(site.name)</title>\
+            <title>\(xmlEscape(site.name))</title>\
             <link>\(site.url.absoluteString)</link>\
             <width>\(image.width)</width>\
             <height>\(image.height)</height>\
@@ -49,7 +58,7 @@ struct FeedGenerator {
                 var itemXML = """
                 <item>\
                 <guid isPermaLink="true">\(item.path(in: site))</guid>\
-                <title>\(item.title)</title>\
+                <title>\(xmlEscape(item.title))</title>\
                 <link>\(item.path(in: site))</link>\
                 <description><![CDATA[\(item.description)]]></description>\
                 <pubDate>\(item.date.asRFC822(timeZone: site.timeZone))</pubDate>
@@ -86,8 +95,8 @@ struct FeedGenerator {
         xmlns:atom="http://www.w3.org/2005/Atom" \
         xmlns:content="http://purl.org/rss/1.0/modules/content/">\
         <channel>\
-        <title>\(site.name)</title>\
-        <description>\(site.description ?? "")</description>\
+        <title>\(xmlEscape(site.name))</title>\
+        <description>\(xmlEscape(site.description ?? ""))</description>\
         <link>\(site.url.absoluteString)</link>\
         <atom:link
             href="\(site.url.appending(path: feedConfig.path).absoluteString)"

--- a/Tests/IgniteTesting/Publishing/FeedGenerator.swift
+++ b/Tests/IgniteTesting/Publishing/FeedGenerator.swift
@@ -20,6 +20,21 @@ struct FeedGeneratorTests {
         TestSite(timeZone: .init(abbreviation: "EST")!)
     ]
 
+    @Test("XML-escapes special characters in titles")
+    func xmlEscapesSpecialCharacters() async throws {
+        let site = TestSite()
+        let config = site.feedConfiguration!
+        var article = Article()
+        article.title = "Donations & Sponsorships"
+        article.description = "Example Description"
+
+        let generator = FeedGenerator(config: config, site: site, content: [article])
+        let feed = generator.generateFeed()
+
+        #expect(feed.contains("<title>Donations &amp; Sponsorships</title>"))
+        #expect(!feed.contains("<title>Donations & Sponsorships</title>"))
+    }
+
     @Test("generateFeed()", arguments: await sites)
     func generateFeed(for site: any Site) async throws {
         let config = site.feedConfiguration!


### PR DESCRIPTION
## Summary
- Article titles and site metadata containing special XML characters (`&`, `<`, `>`, `"`, `'`) produced invalid RSS that feed readers rejected
- Added `xmlEscape()` helper to `FeedGenerator` to properly encode non-CDATA text fields (item titles, site name, site description)
- Fields already wrapped in `<![CDATA[...]]>` (description, author, tags, content) are unaffected

## Test plan
- Added test verifying `&` in article titles is escaped to `&amp;` in feed output
- All existing `FeedGenerator` tests continue to pass
- Validated output with `xmllint --noout` on a real feed containing titles with `&` characters