### PR TITLE
Add trailing slash to sitemap URLs

### DIFF
--- a/Sources/Ignite/Publishing/SiteMapGenerator.swift
+++ b/Sources/Ignite/Publishing/SiteMapGenerator.swift
@@ -11,7 +11,8 @@ struct SiteMapGenerator {
 
     func generateSiteMap() -> String {
         let locations = context.siteMap.map {
-            "<url><loc>\(context.site.url.absoluteString)\($0.path)</loc><priority>\($0.priority)</priority></url>"
+            let path = $0.path.hasSuffix("/") ? $0.path : $0.path + "/"
+            return "<url><loc>\(context.site.url.absoluteString)\(path)</loc><priority>\($0.priority)</priority></url>"
         }.joined()
 
         return """


### PR DESCRIPTION
## Summary

Ignite generates pages as `directory/index.html`, so the canonical served URL for each page includes a trailing slash (e.g., `/library/` not `/library`). The sitemap was emitting URLs without the trailing slash, causing 301 redirects on hosts like GitHub Pages.

For example, the sitemap would contain:
```xml
<loc>https://example.com/library</loc>
```
But the actual page is served at `https://example.com/library/`, resulting in a 301 redirect. This means search engines follow an unnecessary redirect for every page in the sitemap.

This fix ensures sitemap `<loc>` URLs include a trailing slash to match the actual served URLs, avoiding the redirects.

- Paths that already end in `/` (like the root `/`) are left unchanged
- Only affects sitemap URL output — internal path storage is unchanged

## Test plan

- [x] `swift build` passes
- [x] Verified existing tests still pass
- [ ] Rebuild a site and confirm sitemap URLs now end in `/`