### PR TITLE
Fix Markdown block rendering in Text

### DIFF
--- a/Sources/Ignite/Elements/Text.swift
+++ b/Sources/Ignite/Elements/Text.swift
@@ -5,6 +5,8 @@
 // See LICENSE for license information.
 //
 
+import SwiftSoup
+
 /// A structured piece of text, such as a paragraph of heading. If you are just
 /// placing content inside a list, table, table header, and so on, you can usually
 /// just use a simple string. Using `Text` is required if you want a specific paragraph
@@ -28,8 +30,8 @@ public struct Text: HTML, DropdownItem {
     /// The content to place inside the text.
     private var content: any BodyElement
 
-    /// Whether this text contains multiple paragraphs of Markdown content.
-    private var isMultilineMarkdown = false
+    /// Whether this text should wrap rendered markup in a container rather than a paragraph tag.
+    private var wrapsBlockMarkup = false
 
     /// Creates a new `Text` instance using an inline element builder that
     /// returns an array of the content to place into the text.
@@ -109,28 +111,10 @@ public struct Text: HTML, DropdownItem {
     /// Creates a new Text struct from a Markdown string.
     /// - Parameter markdown: The Markdown text to parse.
     public init(markdown: String) {
-        let parser = MarkdownToHTML(markdown: markdown, removeTitleFromBody: true)
-
-        // Process each paragraph individually to preserve line breaks.
-        // We could simply replace newlines with <br>, but then the paragraphs
-        // wouldn't respond to a theme's paragraphBottomMargin property.
-        if parser.body.contains("</p><p>") {
-            let paragraphs = parser.body
-                .components(separatedBy: "</p><p>")
-                .map {
-                    $0.replacingOccurrences(of: "<p>", with: "")
-                      .replacingOccurrences(of: "</p>", with: "")
-                }
-                .map(Text.init)
-
-            self.content = HTMLCollection(paragraphs)
-            self.isMultilineMarkdown = true
-        } else {
-            // Remove the wrapping <p> tags since they'll be added by markup()
-            let cleanedHTML = parser.body.replacing(#/<\/?p>/#, with: "")
-            self.content = cleanedHTML
-            self.isMultilineMarkdown = false
-        }
+        let parser = MarkdownToHTML(markdown: markdown, removeTitleFromBody: false)
+        let renderedMarkup = Self.renderedMarkupContent(from: parser.body)
+        self.content = renderedMarkup.content
+        self.wrapsBlockMarkup = renderedMarkup.wrapsBlockMarkup
     }
 
     /// Creates a new `Text` struct from a markup format and its parser.
@@ -139,9 +123,10 @@ public struct Text: HTML, DropdownItem {
     ///   - parser: The parser to process the text.
     public init(markup: String, parser: any ArticleRenderer.Type) {
         do {
-            let parser = try parser.init(markdown: markup, removeTitleFromBody: true)
-            let cleanedHTML = parser.body.replacing(#/<\/?p>/#, with: "")
-            self.content = cleanedHTML
+            let parser = try parser.init(markdown: markup, removeTitleFromBody: false)
+            let renderedMarkup = Self.renderedMarkupContent(from: parser.body)
+            self.content = renderedMarkup.content
+            self.wrapsBlockMarkup = renderedMarkup.wrapsBlockMarkup
         } catch {
             self.content = markup
             publishingContext.addError(.failedToParseMarkup)
@@ -151,11 +136,9 @@ public struct Text: HTML, DropdownItem {
     /// Renders this element using publishing context passed in.
     /// - Returns: The HTML for this element.
     public func markup() -> Markup {
-        if isMultilineMarkdown {
-            // HTMLCollection will pass its attributes to each child.
-            // This works fine for styles like color, but for styles like
-            // padding, we'd expect them to apply to the paragraphs
-            // collectively. So we'll wrap the paragraphs in a Section.
+        if wrapsBlockMarkup {
+            // Block-level markup needs a container so the HTML stays valid and
+            // modifiers continue to apply collectively rather than per child.
             Section(content)
                 .attributes(attributes)
                 .markup()
@@ -166,6 +149,44 @@ public struct Text: HTML, DropdownItem {
                 "</\(font.rawValue)>"
             )
         }
+    }
+}
+
+private extension Text {
+    /// Decides whether parsed markup can be rendered inline or needs a block wrapper.
+    static func renderedMarkupContent(from html: String) -> (content: any BodyElement, wrapsBlockMarkup: Bool) {
+        guard let inlineMarkup = inlineMarkupContent(from: html) else {
+            return (html, true)
+        }
+
+        return (inlineMarkup, false)
+    }
+
+    /// Extracts the contents of a single paragraph when the rendered markup contains nothing else.
+    static func inlineMarkupContent(from html: String) -> String? {
+        guard html.isEmpty == false else {
+            return ""
+        }
+
+        guard
+            let document = try? SwiftSoup.parseBodyFragment(html),
+            let body = document.body()
+        else {
+            return nil
+        }
+
+        let children = body.children()
+
+        guard
+            body.childNodeSize() == 1,
+            children.size() == 1,
+            let paragraph = children.first(),
+            paragraph.tagName() == "p"
+        else {
+            return nil
+        }
+
+        return try? paragraph.html()
     }
 }
 

--- a/Sources/Ignite/Rendering/Markdown/MarkdownToHTML.swift
+++ b/Sources/Ignite/Rendering/Markdown/MarkdownToHTML.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Markdown
+import SwiftSoup
 
 /// A simple Markdown to HTML parser powered by Apple's swift-markdown.
 public struct MarkdownToHTML: ArticleRenderer, MarkupVisitor {
@@ -32,6 +33,11 @@ public struct MarkdownToHTML: ArticleRenderer, MarkupVisitor {
         self.removeTitleFromBody = removeTitleFromBody
         let document = Markdown.Document(parsing: markdown)
         body = visit(document)
+    }
+
+    /// Escapes plain text so rendered Markdown always produces valid HTML.
+    private func escapedHTML(_ text: String) -> String {
+        return Entities.escape(text)
     }
 
     /// Visit some markup when no other handler is suitable.
@@ -66,10 +72,12 @@ public struct MarkdownToHTML: ArticleRenderer, MarkupVisitor {
     /// - Returns: A HTML <pre> element with <code> inside, marked with
     /// CSS to remember which language was used.
     public func visitCodeBlock(_ codeBlock: Markdown.CodeBlock) -> String {
+        let code = escapedHTML(codeBlock.code)
+
         if let language = codeBlock.language {
-            #"<pre><code class="language-\#(language.lowercased())">\#(codeBlock.code)</code></pre>"#
+            return #"<pre><code class="language-\#(language.lowercased())">\#(code)</code></pre>"#
         } else {
-            #"<pre><code>\#(codeBlock.code)</code></pre>"#
+            return #"<pre><code>\#(code)</code></pre>"#
         }
     }
 
@@ -149,7 +157,7 @@ public struct MarkdownToHTML: ArticleRenderer, MarkupVisitor {
     /// - Parameter inlineCode: The inline code markup to process.
     /// - Returns: A HTML <code> tag containing the code.
     mutating public func visitInlineCode(_ inlineCode: Markdown.InlineCode) -> String {
-        "<code>\(inlineCode.code)</code>"
+        "<code>\(escapedHTML(inlineCode.code))</code>"
     }
 
     /// Processes a chunk of inline HTML markup.
@@ -322,7 +330,7 @@ public struct MarkdownToHTML: ArticleRenderer, MarkupVisitor {
     /// - Parameter text: The plain text markup to process.
     /// - Returns: The same text that was read as input.
     mutating public func visitText(_ text: Markdown.Text) -> String {
-        text.plainText
+        escapedHTML(text.plainText)
     }
 
     /// Process thematic break markup. This is written as --- in Markdown.

--- a/Tests/IgniteTesting/Elements/Text.swift
+++ b/Tests/IgniteTesting/Elements/Text.swift
@@ -72,36 +72,22 @@ import Testing
         <p><em>i</em>, <strong>b</strong>, and <em><strong>b&amp;i</strong></em></p>
         """)
     }
-    
-    @Test("Markdown rendering disappearing headings")
-    func markdownRenderingDisappearingHeadings() async throws {
-        let element = Text(markdown: """
-        ## Heading 1
-        Body text 1
-        ## Heading 2
-        Body text 2
-        """)
-        let output = element.markupString()
-        #expect(output.contains("<h2>Heading 1</h2>"))
-        #expect(output.contains("<h2>Heading 2</h2>"))
-    }
-    
-    @Test("Markdown rendering invalid paragraphs")
-    func markdownRenderingInvalidParagraphs() async throws {
+        
+    @Test("Markdown rendering forms correct paragraphs and respects blank lines")
+    func markdownRenderingFormsParagraphsRespectingBlankLines() async throws {
         let element = Text(markdown: """
         ## Heading 1
         Text 1
         
         Text 2
-        
         ## Heading 2
         Text 3
+        Text 4
+        ## Heading 3
+        Text 5
         """)
         let output = element.markupString()
-        #expect(output.contains("<p>Text 1</p>"))
-        #expect(output.contains("<p>Text 2</p>"))
-        #expect(output.contains("<p>Text 3</p>"))
-        #expect(output.contains("<p></p>") == false)
+        #expect(output == "<div><h2>Heading 1</h2><p>Text 1</p><p>Text 2</p><h2>Heading 2</h2><p>Text 3 Text 4</p><h2>Heading 3</h2><p>Text 5</p></div>")
     }
 
     @Test("Markdown rendering preserves block structure")

--- a/Tests/IgniteTesting/Elements/Text.swift
+++ b/Tests/IgniteTesting/Elements/Text.swift
@@ -69,8 +69,65 @@ import Testing
         let output = element.markupString()
 
         #expect(output == """
-        <p><em>i</em>, <strong>b</strong>, and <em><strong>b&i</strong></em></p>
+        <p><em>i</em>, <strong>b</strong>, and <em><strong>b&amp;i</strong></em></p>
         """)
+    }
+    
+    @Test("Markdown rendering disappearing headings")
+    func markdownRenderingDisappearingHeadings() async throws {
+        let element = Text(markdown: """
+        ## Heading 1
+        Body text 1
+        ## Heading 2
+        Body text 2
+        """)
+        let output = element.markupString()
+        #expect(output.contains("<h2>Heading 1</h2>"))
+        #expect(output.contains("<h2>Heading 2</h2>"))
+    }
+    
+    @Test("Markdown rendering invalid paragraphs")
+    func markdownRenderingInvalidParagraphs() async throws {
+        let element = Text(markdown: """
+        ## Heading 1
+        Text 1
+        
+        Text 2
+        
+        ## Heading 2
+        Text 3
+        """)
+        let output = element.markupString()
+        #expect(output.contains("<p>Text 1</p>"))
+        #expect(output.contains("<p>Text 2</p>"))
+        #expect(output.contains("<p>Text 3</p>"))
+        #expect(output.contains("<p></p>") == false)
+    }
+
+    @Test("Markdown rendering preserves block structure")
+    func markdownRenderingPreservesBlockStructure() async throws {
+        let element = Text(markdown: """
+        ## Heading
+        - Item 1
+        - Item 2
+        """)
+        let output = element.markupString()
+        #expect(output == "<div><h2>Heading</h2><ul><li>Item 1</li><li>Item 2</li></ul></div>")
+    }
+
+    @Test("Markup parser preserves block Markdown")
+    func markupParserPreservesBlockMarkdown() async throws {
+        let element = Text(
+            markup: """
+            ## Heading 1
+            Body text 1
+            ## Heading 2
+            Body text 2
+            """,
+            parser: MarkdownToHTML.self
+        )
+        let output = element.markupString()
+        #expect(output == "<div><h2>Heading 1</h2><p>Body text 1</p><h2>Heading 2</h2><p>Body text 2</p></div>")
     }
 
     @Test("Strikethrough")

--- a/Tests/IgniteTesting/Framework/ArticleRenderer.swift
+++ b/Tests/IgniteTesting/Framework/ArticleRenderer.swift
@@ -73,6 +73,21 @@ struct ArticleRendererTests {
         #expect(element.body == "<p>Here is some <code>var code = \"great\"</code></p>")
     }
 
+    @Test("Markdown escapes plain text")
+    func escapesMarkdownPlainText() async throws {
+        let element = MarkdownToHTML(markdown: "AT&T", removeTitleFromBody: false)
+
+        #expect(element.body == "<p>AT&amp;T</p>")
+    }
+
+    @Test("Markdown escapes inline code")
+    func escapesMarkdownInlineCode() async throws {
+        let markdown = "Here is some `a < b && c > d`"
+        let element = MarkdownToHTML(markdown: markdown, removeTitleFromBody: false)
+
+        #expect(element.body == "<p>Here is some <code>a &lt; b &amp;&amp; c &gt; d</code></p>")
+    }
+
     @Test("Markdown emphasis from string", arguments: ["Here is some *emphasized* text"])
     func convertMarkdownEmphasisToHTML(markdown: String) async throws {
         let element = MarkdownToHTML(markdown: markdown, removeTitleFromBody: false)


### PR DESCRIPTION
Fixes #874

This changes `Text(markdown:)` and `Text(markup:parser:)` to preserve block Markdown structure instead of doing fragile HTML string
splitting.

What changed:
- stop stripping the first heading from `Text` Markdown bodies
- detect the true single-paragraph case from parsed HTML
- render block Markdown inside a container so headings/lists/paragraphs remain valid
- escape plain text and inline/code block contents in `MarkdownToHTML` so the renderer always produces valid HTML

Tests:
- preserve multiple headings in `Text(markdown:)`
- avoid invalid paragraph output for mixed block Markdown
- preserve block structure for headings + lists
- cover the same behavior through `Text(markup:parser:)`
- verify Markdown text/code escaping in `MarkdownToHTML`

Validation:
- validated in a separate Ignite-based project against real integration content and against IgniteSamples