### PR TITLE
Fix Unsafe Build Flags error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .executable(name: "IgniteCLI", targets: ["IgniteCLI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-markdown.git", from: "0.6.0"),
+        .package(url: "https://github.com/swiftlang/swift-markdown.git", exact: "0.7.1"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.4"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.7.5")

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-markdown.git", exact: "0.7.1"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
-        .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.4"),
+        .package(url: "https://github.com/apple/swift-collections.git", exact: "1.1.4"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.7.5")
     ],
     targets: [


### PR DESCRIPTION
fix "error: 'ignite': the target 'Markdown' in product 'Markdown' contains unsafe build flags" by changing swift-markdown version to use version 0.7.1 which doesn't have the unsafe build flags