### PR TITLE
Add draft content support foundations

### DIFF
--- a/Sources/Ignite/Elements/DraftBanner.swift
+++ b/Sources/Ignite/Elements/DraftBanner.swift
@@ -1,0 +1,54 @@
+//
+//  DraftBanner.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// A visual banner indicating draft, scheduled, or expired content status.
+/// Renders a fixed-position bar at the top of the page with a status label.
+/// Renders nothing for published content.
+public struct DraftBanner: HTML {
+    /// The content and behavior of this HTML.
+    public var body: some HTML { self }
+
+    /// The standard set of control attributes for HTML elements.
+    public var attributes = CoreAttributes()
+
+    /// Whether this HTML belongs to the framework.
+    public var isPrimitive: Bool { true }
+
+    private let status: ContentStatus
+
+    /// Creates a draft banner for the given content status.
+    /// - Parameter status: The content status to display.
+    public init(status: ContentStatus) {
+        self.status = status
+    }
+
+    public func markup() -> Markup {
+        let (label, color): (String, String) = switch status {
+        case .draft:
+            ("DRAFT", "#dc3545")
+        case .scheduled:
+            ("SCHEDULED", "#fd7e14")
+        case .expired:
+            ("EXPIRED", "#6c757d")
+        case .published:
+            ("", "")
+        }
+
+        guard !label.isEmpty else { return Markup("") }
+
+        return Markup("""
+        <div style="position:fixed;top:0;left:0;right:0;z-index:9999;\
+        background:\(color);color:white;text-align:center;padding:4px 0;\
+        font-size:12px;font-weight:bold;letter-spacing:1px;opacity:0.9;">\
+        \(label) \u{2014} This content will not appear in production builds\
+        </div>\
+        <div style="height:28px;"></div>
+        """)
+    }
+}

--- a/Sources/Ignite/Framework/Article.swift
+++ b/Sources/Ignite/Framework/Article.swift
@@ -308,3 +308,35 @@ extension Article {
         self.hasAutomaticDate = false
     }
 }
+
+// MARK: - Draft and Scheduled Content
+
+extension Article {
+    /// Whether this article is marked as a draft in its YAML front matter.
+    /// Recognized values: `draft: true`, `draft: yes`, `draft: 1`.
+    public var isDraft: Bool {
+        guard let value = metadata["draft"] as? String else { return false }
+        return ["true", "yes", "1"].contains(value.lowercased())
+    }
+
+    /// The scheduled publication date, if set via `scheduled:` in YAML front matter.
+    public var scheduledDate: Date? {
+        guard let dateString = metadata["scheduled"] as? String else { return nil }
+        return process(date: dateString)
+    }
+
+    /// The expiration date, if set via `expires:` in YAML front matter.
+    public var expiresDate: Date? {
+        guard let dateString = metadata["expires"] as? String else { return nil }
+        return process(date: dateString)
+    }
+
+    /// The computed publication status of this article, evaluated against
+    /// the given effective date.
+    public func contentStatus(at effectiveDate: Date = .now) -> ContentStatus {
+        if isDraft { return .draft }
+        if let scheduled = scheduledDate, scheduled > effectiveDate { return .scheduled }
+        if let expires = expiresDate, expires <= effectiveDate { return .expired }
+        return .published
+    }
+}

--- a/Sources/Ignite/Framework/ContentStatus.swift
+++ b/Sources/Ignite/Framework/ContentStatus.swift
@@ -1,0 +1,30 @@
+//
+//  ContentStatus.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// The publication status of a piece of content.
+public enum ContentStatus: String, Sendable, Comparable {
+    /// Content is a work-in-progress, excluded from production builds.
+    case draft
+
+    /// Content is scheduled for a future date, excluded until that date.
+    case scheduled
+
+    /// Content is published and visible in all builds.
+    case published
+
+    /// Content has passed its expiration date.
+    case expired
+
+    public static func < (lhs: ContentStatus, rhs: ContentStatus) -> Bool {
+        let order: [ContentStatus] = [.draft, .scheduled, .published, .expired]
+        guard let lhsIndex = order.firstIndex(of: lhs),
+              let rhsIndex = order.firstIndex(of: rhs) else { return false }
+        return lhsIndex < rhsIndex
+    }
+}

--- a/Tests/IgniteTesting/Elements/DraftBannerTests.swift
+++ b/Tests/IgniteTesting/Elements/DraftBannerTests.swift
@@ -1,0 +1,64 @@
+//
+//  DraftBannerTests.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+import Testing
+
+@testable import Ignite
+
+/// Tests for the `DraftBanner` element.
+@Suite("DraftBanner Tests")
+class DraftBannerTests: IgniteTestSuite {
+
+    @Test("Draft status renders red banner", .publishingContext())
+    func draftBanner() async throws {
+        let output = DraftBanner(status: .draft).markupString()
+
+        #expect(output.contains("DRAFT"))
+        #expect(output.contains("#dc3545"))
+    }
+
+    @Test("Scheduled status renders orange banner", .publishingContext())
+    func scheduledBanner() async throws {
+        let output = DraftBanner(status: .scheduled).markupString()
+
+        #expect(output.contains("SCHEDULED"))
+        #expect(output.contains("#fd7e14"))
+    }
+
+    @Test("Expired status renders gray banner", .publishingContext())
+    func expiredBanner() async throws {
+        let output = DraftBanner(status: .expired).markupString()
+
+        #expect(output.contains("EXPIRED"))
+        #expect(output.contains("#6c757d"))
+    }
+
+    @Test("Published status renders nothing", .publishingContext())
+    func publishedBannerEmpty() async throws {
+        let output = DraftBanner(status: .published).markupString()
+
+        #expect(!output.contains("DRAFT"))
+        #expect(!output.contains("SCHEDULED"))
+        #expect(!output.contains("EXPIRED"))
+    }
+
+    @Test("Banner includes production warning text", .publishingContext())
+    func bannerWarningText() async throws {
+        let output = DraftBanner(status: .draft).markupString()
+
+        #expect(output.contains("will not appear in production builds"))
+    }
+
+    @Test("Banner uses fixed positioning", .publishingContext())
+    func bannerPositioning() async throws {
+        let output = DraftBanner(status: .draft).markupString()
+
+        #expect(output.contains("position:fixed"))
+        #expect(output.contains("z-index:9999"))
+    }
+}

--- a/Tests/IgniteTesting/Framework/ContentStatusTests.swift
+++ b/Tests/IgniteTesting/Framework/ContentStatusTests.swift
@@ -1,0 +1,283 @@
+//
+//  ContentStatusTests.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+import Testing
+
+@testable import Ignite
+
+/// Tests for the `ContentStatus` enum and Article draft/scheduling extensions.
+@Suite("ContentStatus Tests")
+struct ContentStatusTests {
+
+    // MARK: - ContentStatus enum ordering
+
+    @Test("ContentStatus has correct ordering: draft < scheduled < published < expired", .publishingContext())
+    func statusOrdering() async throws {
+        #expect(ContentStatus.draft < .scheduled)
+        #expect(ContentStatus.scheduled < .published)
+        #expect(ContentStatus.published < .expired)
+        #expect(ContentStatus.draft < .expired)
+    }
+
+    @Test("ContentStatus equality works", .publishingContext())
+    func statusEquality() async throws {
+        #expect(ContentStatus.draft == .draft)
+        #expect(ContentStatus.published == .published)
+        #expect(ContentStatus.draft != .published)
+    }
+
+    @Test("ContentStatus raw values are correct strings", .publishingContext())
+    func statusRawValues() async throws {
+        #expect(ContentStatus.draft.rawValue == "draft")
+        #expect(ContentStatus.scheduled.rawValue == "scheduled")
+        #expect(ContentStatus.published.rawValue == "published")
+        #expect(ContentStatus.expired.rawValue == "expired")
+    }
+
+    // MARK: - Article.isDraft
+
+    @Test("isDraft defaults to false", .publishingContext())
+    func isDraftDefault() async throws {
+        let article = Article()
+        #expect(article.isDraft == false)
+    }
+
+    @Test("isDraft recognizes 'true'", .publishingContext())
+    func isDraftTrue() async throws {
+        var article = Article()
+        article.metadata["draft"] = "true"
+        #expect(article.isDraft == true)
+    }
+
+    @Test("isDraft recognizes 'yes'", .publishingContext())
+    func isDraftYes() async throws {
+        var article = Article()
+        article.metadata["draft"] = "yes"
+        #expect(article.isDraft == true)
+    }
+
+    @Test("isDraft recognizes '1'", .publishingContext())
+    func isDraftOne() async throws {
+        var article = Article()
+        article.metadata["draft"] = "1"
+        #expect(article.isDraft == true)
+    }
+
+    @Test("isDraft is case-insensitive", .publishingContext())
+    func isDraftCaseInsensitive() async throws {
+        var article = Article()
+        article.metadata["draft"] = "True"
+        #expect(article.isDraft == true)
+
+        article.metadata["draft"] = "YES"
+        #expect(article.isDraft == true)
+    }
+
+    @Test("isDraft treats unrecognized values as false", .publishingContext())
+    func isDraftUnrecognized() async throws {
+        var article = Article()
+        article.metadata["draft"] = "maybe"
+        #expect(article.isDraft == false)
+    }
+
+    @Test("isDraft treats 'false' as not draft", .publishingContext())
+    func isDraftFalse() async throws {
+        var article = Article()
+        article.metadata["draft"] = "false"
+        #expect(article.isDraft == false)
+    }
+
+    // MARK: - Article.scheduledDate
+
+    @Test("scheduledDate returns nil when not set", .publishingContext())
+    func scheduledDateNil() async throws {
+        let article = Article()
+        #expect(article.scheduledDate == nil)
+    }
+
+    @Test("scheduledDate parses date-only format", .publishingContext())
+    func scheduledDateOnly() async throws {
+        var article = Article()
+        article.metadata["scheduled"] = "2026-06-15"
+
+        let scheduled = try #require(article.scheduledDate)
+        let calendar = Calendar.current
+        let components = calendar.dateComponents(in: .gmt, from: scheduled)
+        #expect(components.year == 2026)
+        #expect(components.month == 6)
+        #expect(components.day == 15)
+    }
+
+    @Test("scheduledDate parses date-time format", .publishingContext())
+    func scheduledDateTime() async throws {
+        var article = Article()
+        article.metadata["scheduled"] = "2026-06-15 09:00"
+
+        let scheduled = try #require(article.scheduledDate)
+        let calendar = Calendar.current
+        let components = calendar.dateComponents(in: .gmt, from: scheduled)
+        #expect(components.year == 2026)
+        #expect(components.month == 6)
+        #expect(components.day == 15)
+        #expect(components.hour == 9)
+        #expect(components.minute == 0)
+    }
+
+    @Test("scheduledDate returns nil for unparseable date", .publishingContext())
+    func scheduledDateInvalid() async throws {
+        var article = Article()
+        article.metadata["scheduled"] = "not-a-date"
+        #expect(article.scheduledDate == nil)
+    }
+
+    // MARK: - Article.expiresDate
+
+    @Test("expiresDate returns nil when not set", .publishingContext())
+    func expiresDateNil() async throws {
+        let article = Article()
+        #expect(article.expiresDate == nil)
+    }
+
+    @Test("expiresDate parses date-only format", .publishingContext())
+    func expiresDateOnly() async throws {
+        var article = Article()
+        article.metadata["expires"] = "2026-09-01"
+
+        let expires = try #require(article.expiresDate)
+        let calendar = Calendar.current
+        let components = calendar.dateComponents(in: .gmt, from: expires)
+        #expect(components.year == 2026)
+        #expect(components.month == 9)
+        #expect(components.day == 1)
+    }
+
+    @Test("expiresDate returns nil for unparseable date", .publishingContext())
+    func expiresDateInvalid() async throws {
+        var article = Article()
+        article.metadata["expires"] = "never"
+        #expect(article.expiresDate == nil)
+    }
+
+    // MARK: - Article.contentStatus(at:)
+
+    @Test("Default article has published status", .publishingContext())
+    func contentStatusDefault() async throws {
+        let article = Article()
+        #expect(article.contentStatus() == .published)
+    }
+
+    @Test("Draft article has draft status regardless of dates", .publishingContext())
+    func contentStatusDraft() async throws {
+        var article = Article()
+        article.metadata["draft"] = "true"
+        #expect(article.contentStatus() == .draft)
+    }
+
+    @Test("Article with future scheduled date has scheduled status", .publishingContext())
+    func contentStatusScheduledFuture() async throws {
+        var article = Article()
+        article.metadata["scheduled"] = "2099-01-01"
+
+        #expect(article.contentStatus() == .scheduled)
+    }
+
+    @Test("Article with past scheduled date has published status", .publishingContext())
+    func contentStatusScheduledPast() async throws {
+        var article = Article()
+        article.metadata["scheduled"] = "2020-01-01"
+
+        #expect(article.contentStatus() == .published)
+    }
+
+    @Test("Article with past expiration date has expired status", .publishingContext())
+    func contentStatusExpired() async throws {
+        var article = Article()
+        article.metadata["expires"] = "2020-01-01"
+
+        #expect(article.contentStatus() == .expired)
+    }
+
+    @Test("Article with future expiration date has published status", .publishingContext())
+    func contentStatusNotYetExpired() async throws {
+        var article = Article()
+        article.metadata["expires"] = "2099-01-01"
+
+        #expect(article.contentStatus() == .published)
+    }
+
+    @Test("Draft takes priority over scheduled", .publishingContext())
+    func contentStatusDraftOverridesScheduled() async throws {
+        var article = Article()
+        article.metadata["draft"] = "true"
+        article.metadata["scheduled"] = "2099-01-01"
+
+        #expect(article.contentStatus() == .draft)
+    }
+
+    @Test("Draft takes priority over expired", .publishingContext())
+    func contentStatusDraftOverridesExpired() async throws {
+        var article = Article()
+        article.metadata["draft"] = "true"
+        article.metadata["expires"] = "2020-01-01"
+
+        #expect(article.contentStatus() == .draft)
+    }
+
+    @Test("Scheduled takes priority over expired when both future", .publishingContext())
+    func contentStatusScheduledBeforeExpires() async throws {
+        var article = Article()
+        article.metadata["scheduled"] = "2099-06-01"
+        article.metadata["expires"] = "2099-12-01"
+
+        #expect(article.contentStatus() == .scheduled)
+    }
+
+    @Test("contentStatus respects effectiveDate parameter", .publishingContext())
+    func contentStatusWithEffectiveDate() async throws {
+        var article = Article()
+        article.metadata["scheduled"] = "2026-06-15"
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "y-M-d"
+        formatter.timeZone = .gmt
+
+        let beforeScheduled = try #require(formatter.date(from: "2026-06-14"))
+        let afterScheduled = try #require(formatter.date(from: "2026-06-16"))
+
+        #expect(article.contentStatus(at: beforeScheduled) == .scheduled)
+        #expect(article.contentStatus(at: afterScheduled) == .published)
+    }
+
+    @Test("contentStatus date simulation works for expiration", .publishingContext())
+    func contentStatusExpirationWithEffectiveDate() async throws {
+        var article = Article()
+        article.metadata["expires"] = "2026-09-01"
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "y-M-d"
+        formatter.timeZone = .gmt
+
+        let beforeExpires = try #require(formatter.date(from: "2026-08-31"))
+        let onExpires = try #require(formatter.date(from: "2026-09-01"))
+
+        #expect(article.contentStatus(at: beforeExpires) == .published)
+        #expect(article.contentStatus(at: onExpires) == .expired)
+    }
+
+    // MARK: - Backward compatibility
+
+    @Test("isPublished false still works independently of isDraft", .publishingContext())
+    func isPublishedAndIsDraftAreIndependent() async throws {
+        var article = Article()
+        article.metadata["published"] = "false"
+
+        #expect(article.isPublished == false)
+        #expect(article.isDraft == false)
+        #expect(article.contentStatus() == .published)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ContentStatus` enum (draft/scheduled/published/expired) with `Comparable` conformance
- Extends `Article` with `isDraft`, `scheduledDate`, `expiresDate`, and `contentStatus(at:)` computed properties
- Adds `DraftBanner` component rendering fixed-position status banners with color coding
- 35 new tests covering all status transitions, date parsing, and banner rendering

## Design
Purely additive — new files and one Article extension. No modifications to the publishing pipeline. Integration with `BuildOptions` and content filtering is planned as a follow-up PR.

## Test plan
- [x] All 35 new tests pass
- [x] Full test suite passes (1353 tests)
- [x] `swift build` clean with no warnings