### PR TITLE
Add pagination foundations

### DIFF
--- a/Sources/Ignite/Elements/Pager.swift
+++ b/Sources/Ignite/Elements/Pager.swift
@@ -1,0 +1,137 @@
+//
+//  Pager.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// A navigation component that renders Bootstrap 5 pagination controls.
+public struct Pager: HTML {
+    /// The content and behavior of this HTML.
+    public var body: some HTML { self }
+
+    /// The standard set of control attributes for HTML elements.
+    public var attributes = CoreAttributes()
+
+    /// Whether this HTML belongs to the framework.
+    public var isPrimitive: Bool { true }
+
+    /// The visual style for the pager.
+    public enum Style: Sendable {
+        /// Previous/Next links only.
+        case prevNext
+
+        /// Numbered page links with prev/next.
+        case numbered
+
+        /// Numbered with ellipsis for large page counts.
+        case compact
+    }
+
+    private let context: PaginationContext
+    private let style: Style
+    private let maxVisiblePages: Int
+
+    /// Creates a pagination navigation component.
+    /// - Parameters:
+    ///   - context: The pagination state to render.
+    ///   - style: The visual style. Defaults to `.numbered`.
+    ///   - maxVisiblePages: Max page links in compact mode. Defaults to 7.
+    public init(context: PaginationContext, style: Style = .numbered, maxVisiblePages: Int = 7) {
+        self.context = context
+        self.style = style
+        self.maxVisiblePages = maxVisiblePages
+    }
+
+    public func markup() -> Markup {
+        guard context.totalPages > 1 else {
+            return Markup("")
+        }
+
+        var items = [String]()
+
+        let prevDisabled = context.hasPreviousPage ? "" : " disabled"
+        let prevHref = context.previousPagePath ?? "#"
+        items.append("""
+        <li class="page-item\(prevDisabled)">\
+        <a class="page-link" href="\(prevHref)">Previous</a></li>
+        """)
+
+        switch style {
+        case .prevNext:
+            break
+        case .numbered:
+            for page in 1...context.totalPages {
+                let active = page == context.currentPage ? " active" : ""
+                let href = context.path(forPage: page)
+                items.append("""
+                <li class="page-item\(active)">\
+                <a class="page-link" href="\(href)">\(page)</a></li>
+                """)
+            }
+        case .compact:
+            let pageNumbers = compactPageNumbers()
+            for entry in pageNumbers {
+                if entry == 0 {
+                    items.append("""
+                    <li class="page-item disabled">\
+                    <span class="page-link">&hellip;</span></li>
+                    """)
+                } else {
+                    let active = entry == context.currentPage ? " active" : ""
+                    let href = context.path(forPage: entry)
+                    items.append("""
+                    <li class="page-item\(active)">\
+                    <a class="page-link" href="\(href)">\(entry)</a></li>
+                    """)
+                }
+            }
+        }
+
+        let nextDisabled = context.hasNextPage ? "" : " disabled"
+        let nextHref = context.nextPagePath ?? "#"
+        items.append("""
+        <li class="page-item\(nextDisabled)">\
+        <a class="page-link" href="\(nextHref)">Next</a></li>
+        """)
+
+        let listContent = items.joined()
+        return Markup("""
+        <nav aria-label="Page navigation">\
+        <ul class="pagination justify-content-center">\
+        \(listContent)\
+        </ul></nav>
+        """)
+    }
+
+    private func compactPageNumbers() -> [Int] {
+        let total = context.totalPages
+        let current = context.currentPage
+
+        if total <= maxVisiblePages {
+            return Array(1...total)
+        }
+
+        var pages = [Int]()
+        let sideCount = (maxVisiblePages - 3) / 2
+
+        pages.append(1)
+
+        let leftBound = max(2, current - sideCount)
+        let rightBound = min(total - 1, current + sideCount)
+
+        if leftBound > 2 { pages.append(0) }
+
+        for page in leftBound...rightBound {
+            pages.append(page)
+        }
+
+        if rightBound < total - 1 { pages.append(0) }
+
+        pages.append(total)
+
+        return pages
+    }
+}

--- a/Sources/Ignite/Framework/PaginationContext.swift
+++ b/Sources/Ignite/Framework/PaginationContext.swift
@@ -1,0 +1,56 @@
+//
+//  PaginationContext.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// Provides pagination state to the current page being rendered.
+public struct PaginationContext: Sendable {
+    /// The current page number (1-indexed).
+    public let currentPage: Int
+
+    /// The total number of pages.
+    public let totalPages: Int
+
+    /// The base path for this paginated section (e.g., "/blog/").
+    public let basePath: String
+
+    /// The URL path for a specific page number.
+    /// Page 1 uses the base path; subsequent pages use /page/N/.
+    public func path(forPage page: Int) -> String {
+        guard page > 1 else { return basePath }
+        return "\(basePath)page/\(page)/"
+    }
+
+    /// Whether there is a previous page.
+    public var hasPreviousPage: Bool { currentPage > 1 }
+
+    /// Whether there is a next page.
+    public var hasNextPage: Bool { currentPage < totalPages }
+
+    /// The path to the previous page, if any.
+    public var previousPagePath: String? {
+        guard hasPreviousPage else { return nil }
+        return path(forPage: currentPage - 1)
+    }
+
+    /// The path to the next page, if any.
+    public var nextPagePath: String? {
+        guard hasNextPage else { return nil }
+        return path(forPage: currentPage + 1)
+    }
+
+    /// Creates a pagination context.
+    /// - Parameters:
+    ///   - currentPage: The current page number (1-indexed).
+    ///   - totalPages: The total number of pages.
+    ///   - basePath: The base URL path for this paginated section.
+    public init(currentPage: Int, totalPages: Int, basePath: String) {
+        self.currentPage = currentPage
+        self.totalPages = totalPages
+        self.basePath = basePath
+    }
+}

--- a/Sources/Ignite/Framework/Paginator.swift
+++ b/Sources/Ignite/Framework/Paginator.swift
@@ -1,0 +1,40 @@
+//
+//  Paginator.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// Splits a collection of content into fixed-size pages for multi-page rendering.
+public struct Paginator<Content: Sendable>: Sendable {
+    /// All items being paginated.
+    public let allItems: [Content]
+
+    /// The number of items per page.
+    public let pageSize: Int
+
+    /// The total number of pages.
+    public var pageCount: Int {
+        guard !allItems.isEmpty else { return 1 }
+        return Int(ceil(Double(allItems.count) / Double(pageSize)))
+    }
+
+    /// The items for a specific page (1-indexed).
+    public func items(forPage page: Int) -> [Content] {
+        guard page >= 1, page <= pageCount, !allItems.isEmpty else { return [] }
+        let start = (page - 1) * pageSize
+        let end = min(start + pageSize, allItems.count)
+        return Array(allItems[start..<end])
+    }
+
+    /// Creates a paginator for the given items.
+    /// - Parameters:
+    ///   - items: The full collection to paginate.
+    ///   - pageSize: Number of items per page. Clamped to a minimum of 1. Defaults to 10.
+    public init(_ items: [Content], pageSize: Int = 10) {
+        self.allItems = items
+        self.pageSize = max(1, pageSize)
+    }
+}

--- a/Tests/IgniteTesting/Elements/PagerTests.swift
+++ b/Tests/IgniteTesting/Elements/PagerTests.swift
@@ -1,0 +1,121 @@
+//
+//  PagerTests.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+import Testing
+
+@testable import Ignite
+
+/// Tests for the `Pager` element.
+@Suite("Pager Tests")
+class PagerTests: IgniteTestSuite {
+
+    // MARK: - prevNext style
+
+    @Test("prevNext on first page disables Previous, enables Next", .publishingContext())
+    func prevNextFirstPage() async throws {
+        let context = PaginationContext(currentPage: 1, totalPages: 3, basePath: "/blog/")
+        let output = Pager(context: context, style: .prevNext).markupString()
+
+        #expect(output.contains("aria-label=\"Page navigation\""))
+        #expect(output.contains("disabled"))
+        #expect(output.contains("Previous"))
+        #expect(output.contains("href=\"/blog/page/2/\""))
+        #expect(output.contains("Next"))
+    }
+
+    @Test("prevNext on last page enables Previous, disables Next", .publishingContext())
+    func prevNextLastPage() async throws {
+        let context = PaginationContext(currentPage: 3, totalPages: 3, basePath: "/blog/")
+        let output = Pager(context: context, style: .prevNext).markupString()
+
+        #expect(output.contains("href=\"/blog/page/2/\""))
+        #expect(output.contains("Previous"))
+        let nextDisabled = output.contains("disabled") && output.contains("Next")
+        #expect(nextDisabled)
+    }
+
+    @Test("prevNext on middle page enables both", .publishingContext())
+    func prevNextMiddlePage() async throws {
+        let context = PaginationContext(currentPage: 2, totalPages: 3, basePath: "/blog/")
+        let output = Pager(context: context, style: .prevNext).markupString()
+
+        #expect(output.contains("href=\"/blog/\""))
+        #expect(output.contains("href=\"/blog/page/3/\""))
+    }
+
+    // MARK: - numbered style
+
+    @Test("numbered style shows all page numbers", .publishingContext())
+    func numberedShowsAll() async throws {
+        let context = PaginationContext(currentPage: 2, totalPages: 3, basePath: "/blog/")
+        let output = Pager(context: context, style: .numbered).markupString()
+
+        #expect(output.contains("href=\"/blog/\""))
+        #expect(output.contains("href=\"/blog/page/2/\""))
+        #expect(output.contains("href=\"/blog/page/3/\""))
+    }
+
+    @Test("numbered style marks current page as active", .publishingContext())
+    func numberedActiveClass() async throws {
+        let context = PaginationContext(currentPage: 2, totalPages: 3, basePath: "/blog/")
+        let output = Pager(context: context, style: .numbered).markupString()
+
+        #expect(output.contains("active"))
+    }
+
+    @Test("numbered style uses Bootstrap pagination classes", .publishingContext())
+    func numberedBootstrapClasses() async throws {
+        let context = PaginationContext(currentPage: 1, totalPages: 2, basePath: "/blog/")
+        let output = Pager(context: context, style: .numbered).markupString()
+
+        #expect(output.contains("pagination"))
+        #expect(output.contains("page-item"))
+        #expect(output.contains("page-link"))
+    }
+
+    // MARK: - compact style
+
+    @Test("compact style uses ellipsis for many pages", .publishingContext())
+    func compactEllipsis() async throws {
+        let context = PaginationContext(currentPage: 5, totalPages: 20, basePath: "/blog/")
+        let output = Pager(context: context, style: .compact, maxVisiblePages: 7).markupString()
+
+        #expect(output.contains("&hellip;"))
+    }
+
+    @Test("compact style shows all pages when count is small", .publishingContext())
+    func compactNoEllipsisWhenSmall() async throws {
+        let context = PaginationContext(currentPage: 2, totalPages: 5, basePath: "/blog/")
+        let output = Pager(context: context, style: .compact, maxVisiblePages: 7).markupString()
+
+        #expect(!output.contains("&hellip;"))
+    }
+
+    // MARK: - single page
+
+    @Test("Single page renders empty", .publishingContext())
+    func singlePageEmpty() async throws {
+        let context = PaginationContext(currentPage: 1, totalPages: 1, basePath: "/blog/")
+        let output = Pager(context: context).markupString()
+
+        #expect(!output.contains("page-item"))
+    }
+
+    // MARK: - default style
+
+    @Test("Default style is numbered", .publishingContext())
+    func defaultIsNumbered() async throws {
+        let context = PaginationContext(currentPage: 1, totalPages: 3, basePath: "/blog/")
+        let output = Pager(context: context).markupString()
+
+        #expect(output.contains("page-item"))
+        #expect(output.contains(">1<"))
+        #expect(output.contains(">2<"))
+        #expect(output.contains(">3<"))
+    }
+}

--- a/Tests/IgniteTesting/Framework/PaginatorTests.swift
+++ b/Tests/IgniteTesting/Framework/PaginatorTests.swift
@@ -1,0 +1,203 @@
+//
+//  PaginatorTests.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+import Testing
+
+@testable import Ignite
+
+/// Tests for the `Paginator` type and `PaginationContext`.
+@Suite("Paginator Tests")
+struct PaginatorTests {
+
+    // MARK: - Paginator: page count
+
+    @Test("25 items with pageSize 10 produces 3 pages", .publishingContext())
+    func pageCountStandard() async throws {
+        let items = Array(1...25)
+        let paginator = Paginator(items, pageSize: 10)
+        #expect(paginator.pageCount == 3)
+    }
+
+    @Test("10 items with pageSize 10 produces exactly 1 page", .publishingContext())
+    func pageCountExact() async throws {
+        let items = Array(1...10)
+        let paginator = Paginator(items, pageSize: 10)
+        #expect(paginator.pageCount == 1)
+    }
+
+    @Test("0 items produces 1 page", .publishingContext())
+    func pageCountEmpty() async throws {
+        let paginator = Paginator([Int](), pageSize: 10)
+        #expect(paginator.pageCount == 1)
+    }
+
+    @Test("1 item produces 1 page", .publishingContext())
+    func pageCountSingle() async throws {
+        let paginator = Paginator([42], pageSize: 10)
+        #expect(paginator.pageCount == 1)
+    }
+
+    @Test("pageSize 1 produces N pages", .publishingContext())
+    func pageCountSizeOne() async throws {
+        let items = Array(1...5)
+        let paginator = Paginator(items, pageSize: 1)
+        #expect(paginator.pageCount == 5)
+    }
+
+    @Test("Very large pageSize produces 1 page", .publishingContext())
+    func pageCountLargeSize() async throws {
+        let items = Array(1...5)
+        let paginator = Paginator(items, pageSize: 1000)
+        #expect(paginator.pageCount == 1)
+    }
+
+    @Test("Constructor clamps pageSize to minimum of 1", .publishingContext())
+    func pageSizeClamped() async throws {
+        let paginator = Paginator([1, 2, 3], pageSize: 0)
+        #expect(paginator.pageSize == 1)
+        #expect(paginator.pageCount == 3)
+
+        let negPaginator = Paginator([1, 2, 3], pageSize: -5)
+        #expect(negPaginator.pageSize == 1)
+    }
+
+    @Test("Default pageSize is 10", .publishingContext())
+    func defaultPageSize() async throws {
+        let paginator = Paginator(Array(1...25))
+        #expect(paginator.pageSize == 10)
+        #expect(paginator.pageCount == 3)
+    }
+
+    // MARK: - Paginator: items(forPage:)
+
+    @Test("Page 1 returns first pageSize items", .publishingContext())
+    func itemsFirstPage() async throws {
+        let items = Array(1...25)
+        let paginator = Paginator(items, pageSize: 10)
+        #expect(paginator.items(forPage: 1) == Array(1...10))
+    }
+
+    @Test("Last page returns remaining items", .publishingContext())
+    func itemsLastPage() async throws {
+        let items = Array(1...25)
+        let paginator = Paginator(items, pageSize: 10)
+        #expect(paginator.items(forPage: 3) == Array(21...25))
+    }
+
+    @Test("Middle page returns correct slice", .publishingContext())
+    func itemsMiddlePage() async throws {
+        let items = Array(1...25)
+        let paginator = Paginator(items, pageSize: 10)
+        #expect(paginator.items(forPage: 2) == Array(11...20))
+    }
+
+    @Test("Page 0 returns empty array", .publishingContext())
+    func itemsPageZero() async throws {
+        let paginator = Paginator(Array(1...10), pageSize: 5)
+        #expect(paginator.items(forPage: 0).isEmpty)
+    }
+
+    @Test("Negative page returns empty array", .publishingContext())
+    func itemsNegativePage() async throws {
+        let paginator = Paginator(Array(1...10), pageSize: 5)
+        #expect(paginator.items(forPage: -1).isEmpty)
+    }
+
+    @Test("Page beyond pageCount returns empty array", .publishingContext())
+    func itemsBeyondRange() async throws {
+        let paginator = Paginator(Array(1...10), pageSize: 5)
+        #expect(paginator.items(forPage: 3).isEmpty)
+    }
+
+    @Test("Empty paginator returns empty for page 1", .publishingContext())
+    func itemsEmptyPaginator() async throws {
+        let paginator = Paginator([Int](), pageSize: 10)
+        #expect(paginator.items(forPage: 1).isEmpty)
+    }
+
+    // MARK: - Paginator: allItems preserved
+
+    @Test("allItems preserves input order", .publishingContext())
+    func allItemsPreserved() async throws {
+        let items = [5, 3, 1, 4, 2]
+        let paginator = Paginator(items, pageSize: 2)
+        #expect(paginator.allItems == [5, 3, 1, 4, 2])
+    }
+}
+
+/// Tests for the `PaginationContext` type.
+@Suite("PaginationContext Tests")
+struct PaginationContextTests {
+
+    // MARK: - Path generation
+
+    @Test("Page 1 uses base path", .publishingContext())
+    func pathPageOne() async throws {
+        let context = PaginationContext(currentPage: 1, totalPages: 3, basePath: "/blog/")
+        #expect(context.path(forPage: 1) == "/blog/")
+    }
+
+    @Test("Page 2 uses /page/2/ suffix", .publishingContext())
+    func pathPageTwo() async throws {
+        let context = PaginationContext(currentPage: 1, totalPages: 3, basePath: "/blog/")
+        #expect(context.path(forPage: 2) == "/blog/page/2/")
+    }
+
+    @Test("Page 3 uses /page/3/ suffix", .publishingContext())
+    func pathPageThree() async throws {
+        let context = PaginationContext(currentPage: 1, totalPages: 5, basePath: "/blog/")
+        #expect(context.path(forPage: 3) == "/blog/page/3/")
+    }
+
+    // MARK: - Navigation helpers
+
+    @Test("Page 1 has no previous page", .publishingContext())
+    func noPreviousOnFirstPage() async throws {
+        let context = PaginationContext(currentPage: 1, totalPages: 3, basePath: "/blog/")
+        #expect(context.hasPreviousPage == false)
+        #expect(context.previousPagePath == nil)
+    }
+
+    @Test("Last page has no next page", .publishingContext())
+    func noNextOnLastPage() async throws {
+        let context = PaginationContext(currentPage: 3, totalPages: 3, basePath: "/blog/")
+        #expect(context.hasNextPage == false)
+        #expect(context.nextPagePath == nil)
+    }
+
+    @Test("Middle page has both previous and next", .publishingContext())
+    func middlePageHasBoth() async throws {
+        let context = PaginationContext(currentPage: 2, totalPages: 3, basePath: "/blog/")
+        #expect(context.hasPreviousPage == true)
+        #expect(context.hasNextPage == true)
+        #expect(context.previousPagePath == "/blog/")
+        #expect(context.nextPagePath == "/blog/page/3/")
+    }
+
+    @Test("Previous page from page 3 is /page/2/", .publishingContext())
+    func previousPagePath() async throws {
+        let context = PaginationContext(currentPage: 3, totalPages: 5, basePath: "/blog/")
+        #expect(context.previousPagePath == "/blog/page/2/")
+    }
+
+    @Test("Single-page context has neither previous nor next", .publishingContext())
+    func singlePage() async throws {
+        let context = PaginationContext(currentPage: 1, totalPages: 1, basePath: "/blog/")
+        #expect(context.hasPreviousPage == false)
+        #expect(context.hasNextPage == false)
+    }
+
+    // MARK: - Properties
+
+    @Test("Context exposes current page and total pages", .publishingContext())
+    func properties() async throws {
+        let context = PaginationContext(currentPage: 2, totalPages: 5, basePath: "/articles/")
+        #expect(context.currentPage == 2)
+        #expect(context.totalPages == 5)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds generic `Paginator<Content>` type for slicing collections into pages
- Adds `PaginationContext` for tracking page state and generating URLs
- Adds `Pager` component rendering Bootstrap 5 pagination controls with three styles: prevNext, numbered, and compact (with ellipsis)
- 35 new tests covering pagination math, URL generation, and all rendering styles

## Design
Purely additive — all new files. `Pager` accepts `PaginationContext` as an explicit parameter rather than using `@Environment`, making it usable immediately without framework changes. Environment key integration and `PaginatedPage` protocol are planned as follow-ups.

## Test plan
- [x] All 35 new tests pass
- [x] Full test suite passes (1353 tests)
- [x] `swift build` clean with no warnings