### PR TITLE
Add ArticleQuery chainable builder

### DIFF
--- a/Sources/Ignite/Framework/ArticleQuery.swift
+++ b/Sources/Ignite/Framework/ArticleQuery.swift
@@ -1,0 +1,245 @@
+//
+//  ArticleQuery.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// A sort field for ordering articles.
+public enum ArticleSortField: Sendable {
+    case date
+    case title
+}
+
+/// A chainable query builder for filtering, sorting, and paginating articles.
+public struct ArticleQuery: Sendable {
+    private let source: [Article]
+    private let filters: [ArticleFilter]
+    private let sortField: ArticleSortField?
+    private let sortOrder: SortOrder
+    private let limitCount: Int?
+    private let offsetCount: Int?
+
+    /// Creates a query over the given articles.
+    public init(_ articles: [Article]) {
+        self.source = articles
+        self.filters = []
+        self.sortField = nil
+        self.sortOrder = .forward
+        self.limitCount = nil
+        self.offsetCount = nil
+    }
+
+    private init(
+        source: [Article],
+        filters: [ArticleFilter],
+        sortField: ArticleSortField?,
+        sortOrder: SortOrder,
+        limitCount: Int?,
+        offsetCount: Int?
+    ) {
+        self.source = source
+        self.filters = filters
+        self.sortField = sortField
+        self.sortOrder = sortOrder
+        self.limitCount = limitCount
+        self.offsetCount = offsetCount
+    }
+
+    // MARK: - Tag filtering
+
+    /// Filters to articles containing the given tag.
+    public func tagged(_ tag: String) -> ArticleQuery {
+        adding(.tagged(tag))
+    }
+
+    /// Filters to articles containing any of the given tags.
+    public func tagged(anyOf tags: [String]) -> ArticleQuery {
+        adding(.taggedAnyOf(tags))
+    }
+
+    /// Filters to articles containing all of the given tags.
+    public func tagged(allOf tags: [String]) -> ArticleQuery {
+        adding(.taggedAllOf(tags))
+    }
+
+    // MARK: - Author filtering
+
+    /// Filters to articles by the given author.
+    public func by(author: String) -> ArticleQuery {
+        adding(.author(author))
+    }
+
+    // MARK: - Published filtering
+
+    /// Filters to articles where `isPublished` is true.
+    public func published() -> ArticleQuery {
+        adding(.published)
+    }
+
+    // MARK: - Date filtering
+
+    /// Filters to articles with a date after the given date.
+    public func after(_ date: Date) -> ArticleQuery {
+        adding(.after(date))
+    }
+
+    /// Filters to articles with a date before the given date.
+    public func before(_ date: Date) -> ArticleQuery {
+        adding(.before(date))
+    }
+
+    /// Filters to articles with a date between the given dates (inclusive start, exclusive end).
+    public func between(_ start: Date, and end: Date) -> ArticleQuery {
+        adding(.between(start, end))
+    }
+
+    // MARK: - Custom filtering
+
+    /// Filters articles using a custom predicate.
+    public func filter(_ predicate: @escaping @Sendable (Article) -> Bool) -> ArticleQuery {
+        adding(.custom(predicate))
+    }
+
+    /// Filters to articles where a metadata key matches the given value.
+    public func metadata(_ key: String, equals value: String) -> ArticleQuery {
+        adding(.metadata(key, value))
+    }
+
+    // MARK: - Sorting
+
+    /// Sorts results by the given field and order.
+    public func sorted(by field: ArticleSortField, order: SortOrder = .forward) -> ArticleQuery {
+        ArticleQuery(
+            source: source, filters: filters,
+            sortField: field, sortOrder: order,
+            limitCount: limitCount, offsetCount: offsetCount
+        )
+    }
+
+    // MARK: - Pagination
+
+    /// Limits the number of results returned.
+    public func limit(_ count: Int) -> ArticleQuery {
+        ArticleQuery(
+            source: source, filters: filters,
+            sortField: sortField, sortOrder: sortOrder,
+            limitCount: count, offsetCount: offsetCount
+        )
+    }
+
+    /// Skips the first N results.
+    public func offset(_ count: Int) -> ArticleQuery {
+        ArticleQuery(
+            source: source, filters: filters,
+            sortField: sortField, sortOrder: sortOrder,
+            limitCount: limitCount, offsetCount: count
+        )
+    }
+
+    /// Returns a specific page of results.
+    public func page(_ page: Int, size: Int) -> ArticleQuery {
+        ArticleQuery(
+            source: source, filters: filters,
+            sortField: sortField, sortOrder: sortOrder,
+            limitCount: size, offsetCount: (page - 1) * size
+        )
+    }
+
+    // MARK: - Evaluation
+
+    /// All articles matching the current filters, sorted and paginated.
+    public var all: [Article] {
+        var result = filtered
+
+        if let field = sortField {
+            result.sort { a, b in
+                switch (field, sortOrder) {
+                case (.date, .forward): a.date < b.date
+                case (.date, .reverse): a.date > b.date
+                case (.title, .forward): a.title < b.title
+                case (.title, .reverse): a.title > b.title
+                }
+            }
+        }
+
+        if let offset = offsetCount {
+            result = Array(result.dropFirst(offset))
+        }
+
+        if let limit = limitCount {
+            result = Array(result.prefix(limit))
+        }
+
+        return result
+    }
+
+    /// The number of results after filtering, sorting, and pagination.
+    public var count: Int { all.count }
+
+    /// The first result, if any.
+    public var first: Article? { all.first }
+
+    /// The total number of filtered results, ignoring limit and offset.
+    public var totalCount: Int { filtered.count }
+
+    // MARK: - Private
+
+    private var filtered: [Article] {
+        source.filter { article in
+            filters.allSatisfy { $0.matches(article) }
+        }
+    }
+
+    private func adding(_ filter: ArticleFilter) -> ArticleQuery {
+        ArticleQuery(
+            source: source, filters: filters + [filter],
+            sortField: sortField, sortOrder: sortOrder,
+            limitCount: limitCount, offsetCount: offsetCount
+        )
+    }
+}
+
+// MARK: - ArticleFilter
+
+private enum ArticleFilter: Sendable {
+    case tagged(String)
+    case taggedAnyOf([String])
+    case taggedAllOf([String])
+    case author(String)
+    case published
+    case after(Date)
+    case before(Date)
+    case between(Date, Date)
+    case metadata(String, String)
+    case custom(@Sendable (Article) -> Bool)
+
+    func matches(_ article: Article) -> Bool {
+        switch self {
+        case .tagged(let tag):
+            return article.tags?.contains(tag) ?? false
+        case .taggedAnyOf(let tags):
+            guard let articleTags = article.tags else { return false }
+            return tags.contains { articleTags.contains($0) }
+        case .taggedAllOf(let tags):
+            guard let articleTags = article.tags else { return false }
+            return tags.allSatisfy { articleTags.contains($0) }
+        case .author(let name):
+            return article.author == name
+        case .published:
+            return article.isPublished
+        case .after(let date):
+            return article.date > date
+        case .before(let date):
+            return article.date < date
+        case .between(let start, let end):
+            return article.date >= start && article.date < end
+        case .metadata(let key, let value):
+            return (article.metadata[key] as? String) == value
+        case .custom(let predicate):
+            return predicate(article)
+        }
+    }
+}

--- a/Tests/IgniteTesting/Framework/ArticleQueryTests.swift
+++ b/Tests/IgniteTesting/Framework/ArticleQueryTests.swift
@@ -1,0 +1,236 @@
+//
+//  ArticleQueryTests.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+import Testing
+
+@testable import Ignite
+
+/// Tests for the `ArticleQuery` chainable builder.
+@Suite("ArticleQuery Tests")
+struct ArticleQueryTests {
+
+    // MARK: - Test data
+
+    static func makeArticle(
+        title: String,
+        tags: String? = nil,
+        author: String? = nil,
+        published: String? = nil,
+        date: Date = .now
+    ) -> Article {
+        var article = Article()
+        article.title = title
+        if let tags { article.metadata["tags"] = tags }
+        if let author { article.metadata["author"] = author }
+        if let published { article.metadata["published"] = published }
+        article.metadata["date"] = date
+        return article
+    }
+
+    static let formatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "y-M-d"
+        f.timeZone = .gmt
+        return f
+    }()
+
+    static func date(_ string: String) -> Date {
+        formatter.date(from: string) ?? .now
+    }
+
+    let articles = [
+        makeArticle(title: "Swift Tips", tags: "swift, tips", author: "Alice", date: date("2026-01-15")),
+        makeArticle(title: "Ignite Guide", tags: "swift, ignite", author: "Bob", date: date("2026-02-10")),
+        makeArticle(title: "Web Basics", tags: "web, html", author: "Alice", date: date("2026-03-05")),
+        makeArticle(title: "Draft Post", tags: "swift", published: "false", date: date("2026-04-01")),
+        makeArticle(title: "Old Post", tags: "misc", author: "Charlie", date: date("2025-06-01"))
+    ]
+
+    // MARK: - Basic query
+
+    @Test("Query all returns all articles", .publishingContext())
+    func queryAll() async throws {
+        let result = ArticleQuery(articles).all
+        #expect(result.count == 5)
+    }
+
+    @Test("Query count returns correct count", .publishingContext())
+    func queryCount() async throws {
+        #expect(ArticleQuery(articles).count == 5)
+    }
+
+    @Test("Query first returns first article", .publishingContext())
+    func queryFirst() async throws {
+        let first = ArticleQuery(articles).first
+        #expect(first?.title == "Swift Tips")
+    }
+
+    @Test("Empty source returns empty results", .publishingContext())
+    func emptySource() async throws {
+        #expect(ArticleQuery([Article]()).all.isEmpty)
+        #expect(ArticleQuery([Article]()).first == nil)
+        #expect(ArticleQuery([Article]()).count == 0)
+    }
+
+    // MARK: - Tag filtering
+
+    @Test("Filter by single tag", .publishingContext())
+    func taggedSingle() async throws {
+        let result = ArticleQuery(articles).tagged("swift").all
+        #expect(result.count == 3)
+    }
+
+    @Test("Filter by tag excludes non-matching", .publishingContext())
+    func taggedExcludes() async throws {
+        let result = ArticleQuery(articles).tagged("html").all
+        #expect(result.count == 1)
+        #expect(result.first?.title == "Web Basics")
+    }
+
+    @Test("Filter by any of multiple tags", .publishingContext())
+    func taggedAnyOf() async throws {
+        let result = ArticleQuery(articles).tagged(anyOf: ["ignite", "html"]).all
+        #expect(result.count == 2)
+    }
+
+    @Test("Filter by all of multiple tags", .publishingContext())
+    func taggedAllOf() async throws {
+        let result = ArticleQuery(articles).tagged(allOf: ["swift", "tips"]).all
+        #expect(result.count == 1)
+        #expect(result.first?.title == "Swift Tips")
+    }
+
+    // MARK: - Author filtering
+
+    @Test("Filter by author", .publishingContext())
+    func byAuthor() async throws {
+        let result = ArticleQuery(articles).by(author: "Alice").all
+        #expect(result.count == 2)
+    }
+
+    @Test("Filter by non-existent author returns empty", .publishingContext())
+    func byAuthorEmpty() async throws {
+        let result = ArticleQuery(articles).by(author: "Nobody").all
+        #expect(result.isEmpty)
+    }
+
+    // MARK: - Published filtering
+
+    @Test("Published filter excludes unpublished", .publishingContext())
+    func publishedFilter() async throws {
+        let result = ArticleQuery(articles).published().all
+        #expect(result.count == 4)
+        #expect(!result.contains(where: { $0.title == "Draft Post" }))
+    }
+
+    // MARK: - Date filtering
+
+    @Test("After date filter", .publishingContext())
+    func afterDate() async throws {
+        let result = ArticleQuery(articles).after(Self.date("2026-02-01")).all
+        #expect(result.count == 3)
+    }
+
+    @Test("Before date filter", .publishingContext())
+    func beforeDate() async throws {
+        let result = ArticleQuery(articles).before(Self.date("2026-02-01")).all
+        #expect(result.count == 2)
+    }
+
+    @Test("Between dates filter", .publishingContext())
+    func betweenDates() async throws {
+        let result = ArticleQuery(articles)
+            .between(Self.date("2026-01-01"), and: Self.date("2026-03-01"))
+            .all
+        #expect(result.count == 2)
+    }
+
+    // MARK: - Custom predicate
+
+    @Test("Custom filter predicate", .publishingContext())
+    func customFilter() async throws {
+        let result = ArticleQuery(articles)
+            .filter { $0.title.contains("Post") }
+            .all
+        #expect(result.count == 2)
+    }
+
+    // MARK: - Metadata filtering
+
+    @Test("Metadata key-value filter", .publishingContext())
+    func metadataFilter() async throws {
+        let result = ArticleQuery(articles).metadata("author", equals: "Bob").all
+        #expect(result.count == 1)
+        #expect(result.first?.title == "Ignite Guide")
+    }
+
+    // MARK: - Sorting
+
+    @Test("Sort by date descending", .publishingContext())
+    func sortByDateDesc() async throws {
+        let result = ArticleQuery(articles).sorted(by: .date, order: .reverse).all
+        #expect(result.first?.title == "Draft Post")
+        #expect(result.last?.title == "Old Post")
+    }
+
+    @Test("Sort by date ascending", .publishingContext())
+    func sortByDateAsc() async throws {
+        let result = ArticleQuery(articles).sorted(by: .date, order: .forward).all
+        #expect(result.first?.title == "Old Post")
+        #expect(result.last?.title == "Draft Post")
+    }
+
+    @Test("Sort by title ascending", .publishingContext())
+    func sortByTitle() async throws {
+        let result = ArticleQuery(articles).sorted(by: .title, order: .forward).all
+        #expect(result.first?.title == "Draft Post")
+        #expect(result.last?.title == "Web Basics")
+    }
+
+    // MARK: - Limit and offset
+
+    @Test("Limit restricts result count", .publishingContext())
+    func limit() async throws {
+        let result = ArticleQuery(articles).limit(2).all
+        #expect(result.count == 2)
+    }
+
+    @Test("Offset skips first N results", .publishingContext())
+    func offset() async throws {
+        let result = ArticleQuery(articles).offset(3).all
+        #expect(result.count == 2)
+    }
+
+    @Test("Page returns correct slice", .publishingContext())
+    func page() async throws {
+        let result = ArticleQuery(articles).page(2, size: 2).all
+        #expect(result.count == 2)
+        #expect(result.first?.title == "Web Basics")
+    }
+
+    @Test("totalCount ignores limit/offset", .publishingContext())
+    func totalCount() async throws {
+        let query = ArticleQuery(articles).tagged("swift").limit(1)
+        #expect(query.count == 1)
+        #expect(query.totalCount == 3)
+    }
+
+    // MARK: - Chaining
+
+    @Test("Multiple filters chain together", .publishingContext())
+    func chainingFilters() async throws {
+        let result = ArticleQuery(articles)
+            .tagged("swift")
+            .published()
+            .sorted(by: .date, order: .reverse)
+            .limit(2)
+            .all
+        #expect(result.count == 2)
+        #expect(result.first?.title == "Ignite Guide")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ArticleQuery` fluent builder for filtering, sorting, and paginating `[Article]` arrays
- Supports tag filtering (single/anyOf/allOf), author and published filters, date range queries, custom predicates, metadata matching
- Sorting by date or title with forward/reverse order
- Limit, offset, and page-based pagination with `totalCount`
- 24 new tests covering all query operations and chaining

## Design
Purely additive — two new files. Operates on `[Article]` directly without requiring `ArticleIndex` or environment modifications. Uses enum-based filters internally for `Sendable` compliance.

## Test plan
- [x] All 24 new tests pass
- [x] Full test suite passes (1353 tests)
- [x] `swift build` clean with no warnings