### PR TITLE
Add search index foundations

### DIFF
--- a/Sources/Ignite/Search/SearchConfiguration.swift
+++ b/Sources/Ignite/Search/SearchConfiguration.swift
@@ -1,0 +1,63 @@
+//
+//  SearchConfiguration.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+/// Configuration for Ignite's built-in search.
+public struct SearchConfiguration: Sendable {
+    /// Whether search index generation is enabled.
+    public var enabled: Bool
+
+    /// Which content types to include in the search index.
+    /// Nil means index all published content.
+    public var contentTypes: [String]?
+
+    /// Maximum length of content excerpts stored in the index (in characters).
+    public var excerptLength: Int
+
+    /// Fields to include in the search index.
+    public var indexedFields: Set<SearchField>
+
+    /// Whether to apply stemming to indexed content.
+    public var enableStemming: Bool
+
+    /// Whether to remove common stop words from the index.
+    public var removeStopWords: Bool
+
+    /// The language for stemming and stop-word lists.
+    public var language: SearchLanguage
+
+    /// Output path for the search index JSON file.
+    public var indexPath: String
+
+    /// Output path for the search JavaScript file.
+    public var scriptPath: String
+
+    /// Default configuration with sensible values.
+    public static let `default` = SearchConfiguration(
+        enabled: true,
+        contentTypes: nil,
+        excerptLength: 300,
+        indexedFields: [.title, .description, .tags, .content, .author],
+        enableStemming: true,
+        removeStopWords: true,
+        language: .english,
+        indexPath: "/search-index.json",
+        scriptPath: "/js/ignite-search.js"
+    )
+
+    /// Disabled configuration.
+    public static let disabled = SearchConfiguration(
+        enabled: false,
+        contentTypes: nil,
+        excerptLength: 0,
+        indexedFields: [],
+        enableStemming: false,
+        removeStopWords: false,
+        language: .english,
+        indexPath: "",
+        scriptPath: ""
+    )
+}

--- a/Sources/Ignite/Search/SearchEntry.swift
+++ b/Sources/Ignite/Search/SearchEntry.swift
@@ -1,0 +1,20 @@
+//
+//  SearchEntry.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// A single entry in the search index, representing one piece of content.
+public struct SearchEntry: Codable, Sendable {
+    public let title: String
+    public let description: String
+    public let url: String
+    public let tags: [String]
+    public let author: String
+    public let excerpt: String
+    public let date: String
+    public let tokens: [String]
+}

--- a/Sources/Ignite/Search/SearchField.swift
+++ b/Sources/Ignite/Search/SearchField.swift
@@ -1,0 +1,26 @@
+//
+//  SearchField.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+/// Fields that can be included in the search index.
+public enum SearchField: String, Sendable, CaseIterable {
+    case title
+    case description
+    case tags
+    case content
+    case author
+
+    /// The relative weight of this field in search ranking.
+    var weight: Double {
+        switch self {
+        case .title: 3.0
+        case .tags: 2.5
+        case .description: 2.0
+        case .author: 1.5
+        case .content: 1.0
+        }
+    }
+}

--- a/Sources/Ignite/Search/SearchIndexGenerator.swift
+++ b/Sources/Ignite/Search/SearchIndexGenerator.swift
@@ -1,0 +1,82 @@
+//
+//  SearchIndexGenerator.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// Generates a search index JSON file from a collection of articles.
+public struct SearchIndexGenerator: Sendable {
+    public let configuration: SearchConfiguration
+    public let articles: [Article]
+
+    public init(configuration: SearchConfiguration, articles: [Article]) {
+        self.configuration = configuration
+        self.articles = articles
+    }
+
+    /// Generates the search index as a JSON string.
+    public func generateIndex() throws -> String {
+        guard configuration.enabled else { return "" }
+
+        let entries = articles
+            .filter { $0.isPublished }
+            .filter { article in
+                guard let types = configuration.contentTypes else { return true }
+                guard let articleType = article.metadata["type"] as? String else { return false }
+                return types.contains(articleType)
+            }
+            .map { buildEntry(for: $0) }
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(entries)
+        return String(data: data, encoding: .utf8) ?? "[]"
+    }
+
+    private func buildEntry(for article: Article) -> SearchEntry {
+        let plainText = TextProcessor.stripHTML(article.text)
+        let excerpt = TextProcessor.excerpt(from: plainText, length: configuration.excerptLength)
+        let tokens = tokenize(article: article)
+
+        return SearchEntry(
+            title: article.title,
+            description: article.description,
+            url: "/\(article.path)",
+            tags: article.tags ?? [],
+            author: article.author ?? "",
+            excerpt: excerpt,
+            date: ISO8601DateFormatter().string(from: article.date),
+            tokens: tokens
+        )
+    }
+
+    private func tokenize(article: Article) -> [String] {
+        var allText = ""
+
+        if configuration.indexedFields.contains(.title) {
+            allText += " " + article.title
+        }
+        if configuration.indexedFields.contains(.description) {
+            allText += " " + article.description
+        }
+        if configuration.indexedFields.contains(.tags) {
+            allText += " " + (article.tags ?? []).joined(separator: " ")
+        }
+        if configuration.indexedFields.contains(.content) {
+            allText += " " + TextProcessor.stripHTML(article.text)
+        }
+        if configuration.indexedFields.contains(.author) {
+            allText += " " + (article.author ?? "")
+        }
+
+        return TextProcessor.tokenize(
+            allText,
+            language: configuration.language,
+            stem: configuration.enableStemming,
+            removeStopWords: configuration.removeStopWords
+        )
+    }
+}

--- a/Sources/Ignite/Search/SearchLanguage.swift
+++ b/Sources/Ignite/Search/SearchLanguage.swift
@@ -1,0 +1,38 @@
+//
+//  SearchLanguage.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+/// Languages supported for stemming and stop-word removal.
+public enum SearchLanguage: String, Sendable {
+    case english = "en"
+    case spanish = "es"
+    case french = "fr"
+    case german = "de"
+
+    /// Stop words for this language.
+    var stopWords: Set<String> {
+        switch self {
+        case .english:
+            return ["a", "an", "the", "is", "are", "was", "were", "be", "been",
+                    "being", "have", "has", "had", "do", "does", "did", "will",
+                    "would", "could", "should", "may", "might", "shall", "can",
+                    "to", "of", "in", "for", "on", "with", "at", "by", "from",
+                    "as", "into", "through", "during", "before", "after", "and",
+                    "but", "or", "nor", "not", "so", "yet", "both", "either",
+                    "neither", "each", "every", "all", "any", "few", "more",
+                    "most", "other", "some", "such", "no", "only", "own",
+                    "same", "than", "too", "very", "just", "about", "above",
+                    "below", "between", "up", "down", "out", "off", "over",
+                    "under", "again", "further", "then", "once", "it", "its",
+                    "this", "that", "these", "those", "i", "me", "my", "we",
+                    "our", "you", "your", "he", "him", "his", "she", "her",
+                    "they", "them", "their", "what", "which", "who", "whom",
+                    "how", "when", "where", "why"]
+        default:
+            return []
+        }
+    }
+}

--- a/Sources/Ignite/Search/TextProcessor.swift
+++ b/Sources/Ignite/Search/TextProcessor.swift
@@ -1,0 +1,93 @@
+//
+//  TextProcessor.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// Text processing utilities for search indexing.
+public enum TextProcessor {
+    /// Removes all HTML tags and entities, collapsing whitespace.
+    public static func stripHTML(_ html: String) -> String {
+        html.replacingOccurrences(of: "<[^>]+>", with: " ", options: .regularExpression)
+            .replacingOccurrences(of: "&[^;]+;", with: " ", options: .regularExpression)
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Generates a plain-text excerpt of the specified length, breaking at a word boundary.
+    public static func excerpt(from text: String, length: Int) -> String {
+        guard text.count > length else { return text }
+        let truncated = String(text.prefix(length))
+        if let lastSpace = truncated.lastIndex(of: " ") {
+            return String(truncated[truncated.startIndex..<lastSpace]) + "..."
+        }
+        return truncated + "..."
+    }
+
+    /// Tokenizes text into individual searchable terms.
+    public static func tokenize(
+        _ text: String,
+        language: SearchLanguage,
+        stem: Bool,
+        removeStopWords: Bool
+    ) -> [String] {
+        let words = text
+            .lowercased()
+            .components(separatedBy: .alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+
+        var tokens = words
+
+        if removeStopWords {
+            let stopWords = language.stopWords
+            tokens = tokens.filter { !stopWords.contains($0) }
+        }
+
+        if stem {
+            tokens = tokens.map { stemWord($0, language: language) }
+        }
+
+        var seen = Set<String>()
+        tokens = tokens.filter { seen.insert($0).inserted }
+
+        return tokens
+    }
+
+    /// Applies basic Porter stemming rules for English.
+    public static func stemWord(_ word: String, language: SearchLanguage) -> String {
+        guard language == .english else { return word }
+        guard word.count > 3 else { return word }
+
+        var stem = word
+
+        let suffixes: [(String, String)] = [
+            ("ousness", "ous"), ("iveness", "ive"), ("fulness", "ful"),
+            ("ization", "ize"), ("ational", "ate"),
+            ("tional", "tion"), ("biliti", "ble"), ("iviti", "ive"),
+            ("aliti", "al"), ("ousli", "ous"), ("entli", "ent"),
+            ("alism", "al"), ("ation", "ate"), ("ator", "ate"),
+            ("anci", "ance"), ("enci", "ence"), ("izer", "ize"),
+            ("alli", "al"), ("eli", "e")
+        ]
+
+        for (suffix, replacement) in suffixes {
+            if stem.hasSuffix(suffix) {
+                return String(stem.dropLast(suffix.count)) + replacement
+            }
+        }
+
+        let simpleSuffixes = ["ing", "tion", "ness", "ment", "able", "ible",
+                              "ful", "less", "ous", "ive", "ly", "ed", "er", "es", "s"]
+        for suffix in simpleSuffixes {
+            if stem.hasSuffix(suffix) && stem.count - suffix.count >= 3 {
+                stem = String(stem.dropLast(suffix.count))
+                break
+            }
+        }
+
+        return stem
+    }
+}

--- a/Tests/IgniteTesting/Search/SearchConfigurationTests.swift
+++ b/Tests/IgniteTesting/Search/SearchConfigurationTests.swift
@@ -1,0 +1,76 @@
+//
+//  SearchConfigurationTests.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+import Testing
+
+@testable import Ignite
+
+/// Tests for the `SearchConfiguration`, `SearchField`, and `SearchLanguage` types.
+@Suite("SearchConfiguration Tests")
+struct SearchConfigurationTests {
+
+    // MARK: - SearchField
+
+    @Test("SearchField weights are ordered by relevance")
+    func fieldWeights() {
+        #expect(SearchField.title.weight > SearchField.content.weight)
+        #expect(SearchField.tags.weight > SearchField.content.weight)
+        #expect(SearchField.description.weight > SearchField.content.weight)
+    }
+
+    @Test("All SearchField cases are accounted for")
+    func allFieldCases() {
+        let all = SearchField.allCases
+        #expect(all.contains(.title))
+        #expect(all.contains(.description))
+        #expect(all.contains(.tags))
+        #expect(all.contains(.content))
+        #expect(all.contains(.author))
+        #expect(all.count == 5)
+    }
+
+    // MARK: - SearchLanguage
+
+    @Test("English stop words include common words")
+    func englishStopWords() {
+        let stops = SearchLanguage.english.stopWords
+        #expect(stops.contains("the"))
+        #expect(stops.contains("a"))
+        #expect(stops.contains("is"))
+        #expect(stops.contains("and"))
+    }
+
+    @Test("Non-English languages return empty stop words")
+    func nonEnglishStopWords() {
+        #expect(SearchLanguage.spanish.stopWords.isEmpty)
+        #expect(SearchLanguage.french.stopWords.isEmpty)
+        #expect(SearchLanguage.german.stopWords.isEmpty)
+    }
+
+    // MARK: - SearchConfiguration
+
+    @Test("Default configuration has sensible values")
+    func defaultConfig() {
+        let config = SearchConfiguration.default
+        #expect(config.enabled)
+        #expect(config.contentTypes == nil)
+        #expect(config.excerptLength == 300)
+        #expect(config.enableStemming)
+        #expect(config.removeStopWords)
+        #expect(config.language == .english)
+        #expect(config.indexedFields.contains(.title))
+        #expect(config.indexedFields.contains(.content))
+    }
+
+    @Test("Disabled configuration has enabled false")
+    func disabledConfig() {
+        let config = SearchConfiguration.disabled
+        #expect(!config.enabled)
+        #expect(config.indexedFields.isEmpty)
+    }
+}

--- a/Tests/IgniteTesting/Search/SearchEntryTests.swift
+++ b/Tests/IgniteTesting/Search/SearchEntryTests.swift
@@ -1,0 +1,63 @@
+//
+//  SearchEntryTests.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+import Testing
+
+@testable import Ignite
+
+/// Tests for the `SearchEntry` type.
+@Suite("SearchEntry Tests")
+struct SearchEntryTests {
+
+    @Test("Codable round-trip preserves all fields")
+    func codableRoundTrip() throws {
+        let entry = SearchEntry(
+            title: "Test Article",
+            description: "A test description",
+            url: "/blog/test-article",
+            tags: ["swift", "testing"],
+            author: "Alice",
+            excerpt: "This is an excerpt...",
+            date: "2026-01-15T00:00:00Z",
+            tokens: ["test", "articl", "swift"]
+        )
+
+        let data = try JSONEncoder().encode(entry)
+        let decoded = try JSONDecoder().decode(SearchEntry.self, from: data)
+
+        #expect(decoded.title == "Test Article")
+        #expect(decoded.description == "A test description")
+        #expect(decoded.url == "/blog/test-article")
+        #expect(decoded.tags == ["swift", "testing"])
+        #expect(decoded.author == "Alice")
+        #expect(decoded.excerpt == "This is an excerpt...")
+        #expect(decoded.date == "2026-01-15T00:00:00Z")
+        #expect(decoded.tokens == ["test", "articl", "swift"])
+    }
+
+    @Test("Empty fields encode correctly")
+    func emptyFields() throws {
+        let entry = SearchEntry(
+            title: "",
+            description: "",
+            url: "/",
+            tags: [],
+            author: "",
+            excerpt: "",
+            date: "",
+            tokens: []
+        )
+
+        let data = try JSONEncoder().encode(entry)
+        let decoded = try JSONDecoder().decode(SearchEntry.self, from: data)
+
+        #expect(decoded.title.isEmpty)
+        #expect(decoded.tags.isEmpty)
+        #expect(decoded.tokens.isEmpty)
+    }
+}

--- a/Tests/IgniteTesting/Search/SearchIndexGeneratorTests.swift
+++ b/Tests/IgniteTesting/Search/SearchIndexGeneratorTests.swift
@@ -1,0 +1,196 @@
+//
+//  SearchIndexGeneratorTests.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+import Testing
+
+@testable import Ignite
+
+/// Tests for the `SearchIndexGenerator`.
+@Suite("SearchIndexGenerator Tests")
+struct SearchIndexGeneratorTests {
+
+    static func makeArticle(
+        title: String,
+        description: String = "",
+        path: String = "blog/test",
+        tags: String? = nil,
+        author: String? = nil,
+        text: String = "",
+        published: String? = nil,
+        type: String = "blog"
+    ) -> Article {
+        var article = Article()
+        article.title = title
+        article.description = description
+        article.path = path
+        article.text = text
+        if let tags { article.metadata["tags"] = tags }
+        if let author { article.metadata["author"] = author }
+        if let published { article.metadata["published"] = published }
+        article.metadata["type"] = type
+        return article
+    }
+
+    let sampleArticles = [
+        makeArticle(
+            title: "Swift Tips",
+            description: "Helpful Swift tips",
+            path: "blog/swift-tips",
+            tags: "swift, tips",
+            author: "Alice",
+            text: "<p>Learn <strong>Swift</strong> programming.</p>"
+        ),
+        makeArticle(
+            title: "Web Guide",
+            description: "Building for the web",
+            path: "blog/web-guide",
+            tags: "web, html",
+            author: "Bob",
+            text: "<p>HTML and CSS basics.</p>"
+        ),
+        makeArticle(
+            title: "Draft Post",
+            path: "blog/draft",
+            published: "false"
+        )
+    ]
+
+    // MARK: - Basic generation
+
+    @Test("Generates entries for published articles only")
+    func generatesPublishedOnly() throws {
+        let generator = SearchIndexGenerator(
+            configuration: .default,
+            articles: sampleArticles
+        )
+        let json = try generator.generateIndex()
+        let entries = try JSONDecoder().decode([SearchEntry].self, from: Data(json.utf8))
+
+        #expect(entries.count == 2)
+        #expect(!entries.contains { $0.title == "Draft Post" })
+    }
+
+    @Test("Disabled configuration returns empty string")
+    func disabledReturnsEmpty() throws {
+        let generator = SearchIndexGenerator(
+            configuration: .disabled,
+            articles: sampleArticles
+        )
+        #expect(try generator.generateIndex().isEmpty)
+    }
+
+    @Test("Entry fields are populated correctly")
+    func entryFields() throws {
+        let generator = SearchIndexGenerator(
+            configuration: .default,
+            articles: sampleArticles
+        )
+        let json = try generator.generateIndex()
+        let entries = try JSONDecoder().decode([SearchEntry].self, from: Data(json.utf8))
+        let swiftEntry = try #require(entries.first { $0.title == "Swift Tips" })
+
+        #expect(swiftEntry.description == "Helpful Swift tips")
+        #expect(swiftEntry.url == "/blog/swift-tips")
+        #expect(swiftEntry.author == "Alice")
+        #expect(swiftEntry.tags == ["swift", "tips"])
+    }
+
+    @Test("Tokens include stemmed content")
+    func tokensAreStemmed() throws {
+        let generator = SearchIndexGenerator(
+            configuration: .default,
+            articles: sampleArticles
+        )
+        let json = try generator.generateIndex()
+        let entries = try JSONDecoder().decode([SearchEntry].self, from: Data(json.utf8))
+        let swiftEntry = try #require(entries.first { $0.title == "Swift Tips" })
+
+        #expect(swiftEntry.tokens.contains("swift"))
+    }
+
+    @Test("Excerpt strips HTML")
+    func excerptStripsHTML() throws {
+        let generator = SearchIndexGenerator(
+            configuration: .default,
+            articles: sampleArticles
+        )
+        let json = try generator.generateIndex()
+        let entries = try JSONDecoder().decode([SearchEntry].self, from: Data(json.utf8))
+        let swiftEntry = try #require(entries.first { $0.title == "Swift Tips" })
+
+        #expect(!swiftEntry.excerpt.contains("<"))
+        #expect(!swiftEntry.excerpt.contains(">"))
+    }
+
+    // MARK: - Content type filtering
+
+    @Test("Filters by content type when configured")
+    func contentTypeFilter() throws {
+        let articles = [
+            Self.makeArticle(title: "Blog Post", path: "blog/post", type: "blog"),
+            Self.makeArticle(title: "Story", path: "stories/story", type: "stories")
+        ]
+
+        var config = SearchConfiguration.default
+        config.contentTypes = ["blog"]
+
+        let generator = SearchIndexGenerator(configuration: config, articles: articles)
+        let json = try generator.generateIndex()
+        let entries = try JSONDecoder().decode([SearchEntry].self, from: Data(json.utf8))
+
+        #expect(entries.count == 1)
+        #expect(entries.first?.title == "Blog Post")
+    }
+
+    @Test("Nil content types includes all articles")
+    func nilContentTypesIncludesAll() throws {
+        let articles = [
+            Self.makeArticle(title: "Blog Post", type: "blog"),
+            Self.makeArticle(title: "Story", type: "stories")
+        ]
+
+        var config = SearchConfiguration.default
+        config.contentTypes = nil
+
+        let generator = SearchIndexGenerator(configuration: config, articles: articles)
+        let json = try generator.generateIndex()
+        let entries = try JSONDecoder().decode([SearchEntry].self, from: Data(json.utf8))
+
+        #expect(entries.count == 2)
+    }
+
+    // MARK: - No stemming
+
+    @Test("Tokens are unstemmed when stemming is disabled")
+    func noStemming() throws {
+        var config = SearchConfiguration.default
+        config.enableStemming = false
+
+        let articles = [Self.makeArticle(title: "Running quickly")]
+        let generator = SearchIndexGenerator(configuration: config, articles: articles)
+        let json = try generator.generateIndex()
+        let entries = try JSONDecoder().decode([SearchEntry].self, from: Data(json.utf8))
+        let entry = try #require(entries.first)
+
+        #expect(entry.tokens.contains("running"))
+        #expect(entry.tokens.contains("quickly"))
+    }
+
+    // MARK: - Empty input
+
+    @Test("Empty article list produces empty index")
+    func emptyArticles() throws {
+        let generator = SearchIndexGenerator(
+            configuration: .default,
+            articles: []
+        )
+        let json = try generator.generateIndex()
+        let entries = try JSONDecoder().decode([SearchEntry].self, from: Data(json.utf8))
+        #expect(entries.isEmpty)
+    }
+}

--- a/Tests/IgniteTesting/Search/TextProcessorTests.swift
+++ b/Tests/IgniteTesting/Search/TextProcessorTests.swift
@@ -1,0 +1,149 @@
+//
+//  TextProcessorTests.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+import Testing
+
+@testable import Ignite
+
+/// Tests for the `TextProcessor` search utility.
+@Suite("TextProcessor Tests")
+struct TextProcessorTests {
+
+    // MARK: - stripHTML
+
+    @Test("Strips simple HTML tags")
+    func stripSimpleTags() {
+        let result = TextProcessor.stripHTML("<p>Hello <b>world</b></p>")
+        #expect(result == "Hello world")
+    }
+
+    @Test("Strips self-closing tags")
+    func stripSelfClosing() {
+        let result = TextProcessor.stripHTML("Line one<br/>Line two")
+        #expect(result == "Line one Line two")
+    }
+
+    @Test("Strips HTML entities")
+    func stripEntities() {
+        let result = TextProcessor.stripHTML("Tom &amp; Jerry &mdash; friends")
+        #expect(result == "Tom Jerry friends")
+    }
+
+    @Test("Collapses multiple whitespace")
+    func collapseWhitespace() {
+        let result = TextProcessor.stripHTML("<p>  hello   world  </p>")
+        #expect(result == "hello world")
+    }
+
+    @Test("Empty string returns empty")
+    func stripEmpty() {
+        #expect(TextProcessor.stripHTML("").isEmpty)
+    }
+
+    @Test("Plain text passes through unchanged")
+    func stripPlainText() {
+        #expect(TextProcessor.stripHTML("no tags here") == "no tags here")
+    }
+
+    // MARK: - excerpt
+
+    @Test("Short text returns unchanged")
+    func excerptShort() {
+        let text = "Hello world"
+        #expect(TextProcessor.excerpt(from: text, length: 100) == "Hello world")
+    }
+
+    @Test("Long text truncates at word boundary with ellipsis")
+    func excerptTruncates() {
+        let text = "The quick brown fox jumps over the lazy dog"
+        let result = TextProcessor.excerpt(from: text, length: 20)
+        #expect(result.hasSuffix("..."))
+        #expect(result.count <= 23)
+    }
+
+    @Test("Empty text returns empty")
+    func excerptEmpty() {
+        #expect(TextProcessor.excerpt(from: "", length: 100).isEmpty)
+    }
+
+    @Test("Excerpt respects word boundary")
+    func excerptWordBoundary() {
+        let text = "Swift programming language"
+        let result = TextProcessor.excerpt(from: text, length: 10)
+        #expect(result == "Swift...")
+    }
+
+    // MARK: - tokenize
+
+    @Test("Tokenizes text into lowercase words")
+    func tokenizeBasic() {
+        let tokens = TextProcessor.tokenize("Hello World Swift", language: .english, stem: false, removeStopWords: false)
+        #expect(tokens.contains("hello"))
+        #expect(tokens.contains("world"))
+        #expect(tokens.contains("swift"))
+    }
+
+    @Test("Removes stop words when enabled")
+    func tokenizeRemovesStopWords() {
+        let tokens = TextProcessor.tokenize(
+            "the quick brown fox is a test",
+            language: .english, stem: false, removeStopWords: true
+        )
+        #expect(!tokens.contains("the"))
+        #expect(!tokens.contains("is"))
+        #expect(!tokens.contains("a"))
+        #expect(tokens.contains("quick"))
+        #expect(tokens.contains("brown"))
+    }
+
+    @Test("Deduplicates tokens")
+    func tokenizeDeduplicates() {
+        let tokens = TextProcessor.tokenize("swift swift swift", language: .english, stem: false, removeStopWords: false)
+        #expect(tokens.count == 1)
+        #expect(tokens.first == "swift")
+    }
+
+    @Test("Splits on non-alphanumeric characters")
+    func tokenizeSplitsOnPunctuation() {
+        let tokens = TextProcessor.tokenize("hello-world foo_bar", language: .english, stem: false, removeStopWords: false)
+        #expect(tokens.contains("hello"))
+        #expect(tokens.contains("world"))
+        #expect(tokens.contains("foo"))
+        #expect(tokens.contains("bar"))
+    }
+
+    @Test("Empty text returns empty tokens")
+    func tokenizeEmpty() {
+        let tokens = TextProcessor.tokenize("", language: .english, stem: false, removeStopWords: false)
+        #expect(tokens.isEmpty)
+    }
+
+    // MARK: - stemWord
+
+    @Test("Stems common English suffixes")
+    func stemCommon() {
+        #expect(TextProcessor.stemWord("running", language: .english) == "runn")
+        #expect(TextProcessor.stemWord("quickly", language: .english) == "quick")
+    }
+
+    @Test("Short words are not stemmed")
+    func stemShortWords() {
+        #expect(TextProcessor.stemWord("the", language: .english) == "the")
+        #expect(TextProcessor.stemWord("is", language: .english) == "is")
+    }
+
+    @Test("Stems ational to ate")
+    func stemAtional() {
+        #expect(TextProcessor.stemWord("informational", language: .english) == "informate")
+    }
+
+    @Test("Non-English words pass through unchanged")
+    func stemNonEnglish() {
+        #expect(TextProcessor.stemWord("running", language: .spanish) == "running")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `TextProcessor` with HTML stripping, excerpt generation, tokenization with Porter stemming and stop-word removal
- Adds `SearchEntry` Codable model for indexed content
- Adds `SearchConfiguration` with sensible defaults and `SearchField`/`SearchLanguage` enums
- Adds `SearchIndexGenerator` producing JSON search indices from Article collections
- 36 new tests covering text processing, configuration, and index generation

## Design
Purely additive — new `Sources/Ignite/Search/` directory. The generator takes `[Article]` as input, making it testable without a publishing context. `SearchBar` component and pipeline integration are planned as follow-ups.

## Test plan
- [x] All 36 new tests pass
- [x] Full test suite passes (1353 tests)
- [x] `swift build` clean with no warnings