### PR TITLE
Add site validation framework

### DIFF
--- a/Sources/Ignite/Validation/RequiredMetadataValidator.swift
+++ b/Sources/Ignite/Validation/RequiredMetadataValidator.swift
@@ -1,0 +1,41 @@
+//
+//  RequiredMetadataValidator.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+/// Enforces that articles have required front matter fields.
+public struct RequiredMetadataValidator: SiteValidator {
+    public let name = "RequiredMetadataValidator"
+
+    /// Front matter fields that every article must have.
+    public var requiredFields: Set<String> = ["description", "image"]
+
+    public init() {}
+
+    public func validate(articles: [Article]) -> [ValidationRule] {
+        articles.flatMap { article in
+            requiredFields.sorted().compactMap { field in
+                let hasField: Bool = switch field {
+                case "description":
+                    !article.description.isEmpty
+                case "image":
+                    article.metadata["image"] != nil
+                default:
+                    article.metadata[field] != nil
+                }
+
+                guard !hasField else { return nil }
+
+                return ValidationRule(
+                    severity: .warning,
+                    message: "Article \"\(article.title)\" is missing required field: \(field)",
+                    source: article.path,
+                    target: nil,
+                    validatorName: name
+                )
+            }
+        }
+    }
+}

--- a/Sources/Ignite/Validation/SiteValidator.swift
+++ b/Sources/Ignite/Validation/SiteValidator.swift
@@ -1,0 +1,12 @@
+//
+//  SiteValidator.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+/// A rule that validates some aspect of a site's content at build time.
+public protocol SiteValidator: Sendable {
+    var name: String { get }
+    func validate(articles: [Article]) -> [ValidationRule]
+}

--- a/Sources/Ignite/Validation/ValidationMode.swift
+++ b/Sources/Ignite/Validation/ValidationMode.swift
@@ -1,0 +1,13 @@
+//
+//  ValidationMode.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+/// Controls how validation findings affect the build.
+public enum ValidationMode: Sendable {
+    case disabled
+    case warn
+    case strict
+}

--- a/Sources/Ignite/Validation/ValidationReport.swift
+++ b/Sources/Ignite/Validation/ValidationReport.swift
@@ -1,0 +1,56 @@
+//
+//  ValidationReport.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+/// The complete result of running all validators against a site.
+public struct ValidationReport: Sendable {
+    public let findings: [ValidationRule]
+
+    public var hasErrors: Bool {
+        findings.contains { $0.severity == .error }
+    }
+
+    public var hasWarnings: Bool {
+        findings.contains { $0.severity >= .warning }
+    }
+
+    public func findings(severity: ValidationSeverity) -> [ValidationRule] {
+        findings.filter { $0.severity == severity }
+    }
+
+    public enum OutputStyle: Sendable {
+        case terminal
+        case xcode
+    }
+
+    public func formatted(style: OutputStyle = .terminal) -> String {
+        guard !findings.isEmpty else { return "No validation issues found." }
+
+        switch style {
+        case .terminal:
+            return findings.map { finding in
+                let label = switch finding.severity {
+                case .info: "info"
+                case .warning: "warning"
+                case .error: "error"
+                }
+                let source = finding.source.map { " [\($0)]" } ?? ""
+                return "[\(label)]\(source) \(finding.message)"
+            }.joined(separator: "\n")
+
+        case .xcode:
+            return findings.map { finding in
+                let label = switch finding.severity {
+                case .info: "note"
+                case .warning: "warning"
+                case .error: "error"
+                }
+                let source = finding.source ?? "<unknown>"
+                return "\(source): \(label): \(finding.message) (\(finding.validatorName))"
+            }.joined(separator: "\n")
+        }
+    }
+}

--- a/Sources/Ignite/Validation/ValidationRule.swift
+++ b/Sources/Ignite/Validation/ValidationRule.swift
@@ -1,0 +1,15 @@
+//
+//  ValidationRule.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+/// A single validation finding.
+public struct ValidationRule: Sendable {
+    public let severity: ValidationSeverity
+    public let message: String
+    public let source: String?
+    public let target: String?
+    public let validatorName: String
+}

--- a/Sources/Ignite/Validation/ValidationSeverity.swift
+++ b/Sources/Ignite/Validation/ValidationSeverity.swift
@@ -1,0 +1,13 @@
+//
+//  ValidationSeverity.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+/// How serious a validation finding is.
+public enum ValidationSeverity: Sendable, Comparable {
+    case info
+    case warning
+    case error
+}

--- a/Tests/IgniteTesting/Validation/RequiredMetadataValidatorTests.swift
+++ b/Tests/IgniteTesting/Validation/RequiredMetadataValidatorTests.swift
@@ -1,0 +1,105 @@
+//
+//  RequiredMetadataValidatorTests.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+import Testing
+
+@testable import Ignite
+
+/// Tests for the `RequiredMetadataValidator`.
+@Suite("RequiredMetadataValidator Tests")
+struct RequiredMetadataValidatorTests {
+
+    static func makeArticle(
+        title: String = "Test",
+        description: String = "",
+        path: String = "blog/test",
+        image: String? = nil,
+        tags: String? = nil
+    ) -> Article {
+        var article = Article()
+        article.title = title
+        article.description = description
+        article.path = path
+        if let image { article.metadata["image"] = image }
+        if let tags { article.metadata["tags"] = tags }
+        return article
+    }
+
+    @Test("Articles with all required fields pass")
+    func allFieldsPresent() {
+        let articles = [
+            Self.makeArticle(description: "A post about Swift", image: "/img/swift.png")
+        ]
+        let validator = RequiredMetadataValidator()
+        let findings = validator.validate(articles: articles)
+        #expect(findings.isEmpty)
+    }
+
+    @Test("Missing description produces warning")
+    func missingDescription() {
+        let articles = [Self.makeArticle(image: "/img/test.png")]
+        let validator = RequiredMetadataValidator()
+        let findings = validator.validate(articles: articles)
+
+        #expect(findings.count == 1)
+        #expect(findings.first?.severity == .warning)
+        #expect(findings.first?.message.contains("description") == true)
+    }
+
+    @Test("Missing image produces warning")
+    func missingImage() {
+        let articles = [Self.makeArticle(description: "Has a description")]
+        let validator = RequiredMetadataValidator()
+        let findings = validator.validate(articles: articles)
+
+        #expect(findings.count == 1)
+        #expect(findings.first?.message.contains("image") == true)
+    }
+
+    @Test("Multiple missing fields produce multiple findings")
+    func multipleMissing() {
+        let articles = [Self.makeArticle()]
+        let validator = RequiredMetadataValidator()
+        let findings = validator.validate(articles: articles)
+
+        #expect(findings.count == 2)
+    }
+
+    @Test("Custom required fields are checked")
+    func customFields() {
+        let articles = [Self.makeArticle()]
+        var validator = RequiredMetadataValidator()
+        validator.requiredFields = ["tags"]
+        let findings = validator.validate(articles: articles)
+
+        #expect(findings.count == 1)
+        #expect(findings.first?.message.contains("tags") == true)
+    }
+
+    @Test("Empty article list produces no findings")
+    func emptyArticles() {
+        let validator = RequiredMetadataValidator()
+        let findings = validator.validate(articles: [])
+        #expect(findings.isEmpty)
+    }
+
+    @Test("Validator name is set correctly")
+    func validatorName() {
+        let validator = RequiredMetadataValidator()
+        #expect(validator.name == "RequiredMetadataValidator")
+    }
+
+    @Test("Source includes article path")
+    func sourceIncludesPath() {
+        let articles = [Self.makeArticle(path: "blog/my-post")]
+        let validator = RequiredMetadataValidator()
+        let findings = validator.validate(articles: articles)
+
+        #expect(findings.allSatisfy { $0.source == "blog/my-post" })
+    }
+}

--- a/Tests/IgniteTesting/Validation/ValidationReportTests.swift
+++ b/Tests/IgniteTesting/Validation/ValidationReportTests.swift
@@ -1,0 +1,122 @@
+//
+//  ValidationReportTests.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+import Testing
+
+@testable import Ignite
+
+/// Tests for core validation types.
+@Suite("ValidationReport Tests")
+struct ValidationReportTests {
+
+    // MARK: - ValidationSeverity
+
+    @Test("Severity is ordered info < warning < error")
+    func severityOrdering() {
+        #expect(ValidationSeverity.info < .warning)
+        #expect(ValidationSeverity.warning < .error)
+        #expect(ValidationSeverity.info < .error)
+    }
+
+    // MARK: - ValidationRule
+
+    @Test("ValidationRule stores all fields")
+    func ruleFields() {
+        let rule = ValidationRule(
+            severity: .error,
+            message: "Missing title",
+            source: "/blog/test",
+            target: nil,
+            validatorName: "TestValidator"
+        )
+
+        #expect(rule.severity == .error)
+        #expect(rule.message == "Missing title")
+        #expect(rule.source == "/blog/test")
+        #expect(rule.target == nil)
+        #expect(rule.validatorName == "TestValidator")
+    }
+
+    // MARK: - ValidationReport
+
+    @Test("Empty report has no errors or warnings")
+    func emptyReport() {
+        let report = ValidationReport(findings: [])
+        #expect(!report.hasErrors)
+        #expect(!report.hasWarnings)
+        #expect(report.findings.isEmpty)
+    }
+
+    @Test("Report detects errors")
+    func reportHasErrors() {
+        let findings = [
+            ValidationRule(severity: .error, message: "broken", source: nil, target: nil, validatorName: "test")
+        ]
+        let report = ValidationReport(findings: findings)
+        #expect(report.hasErrors)
+        #expect(report.hasWarnings)
+    }
+
+    @Test("Report detects warnings without errors")
+    func reportHasWarningsOnly() {
+        let findings = [
+            ValidationRule(severity: .warning, message: "missing image", source: nil, target: nil, validatorName: "test")
+        ]
+        let report = ValidationReport(findings: findings)
+        #expect(!report.hasErrors)
+        #expect(report.hasWarnings)
+    }
+
+    @Test("Findings can be filtered by severity")
+    func filterBySeverity() {
+        let findings = [
+            ValidationRule(severity: .error, message: "e1", source: nil, target: nil, validatorName: "t"),
+            ValidationRule(severity: .warning, message: "w1", source: nil, target: nil, validatorName: "t"),
+            ValidationRule(severity: .info, message: "i1", source: nil, target: nil, validatorName: "t"),
+            ValidationRule(severity: .error, message: "e2", source: nil, target: nil, validatorName: "t")
+        ]
+        let report = ValidationReport(findings: findings)
+
+        #expect(report.findings(severity: .error).count == 2)
+        #expect(report.findings(severity: .warning).count == 1)
+        #expect(report.findings(severity: .info).count == 1)
+    }
+
+    @Test("Formatted output includes finding messages")
+    func formattedOutput() {
+        let findings = [
+            ValidationRule(severity: .error, message: "Missing title", source: "/test", target: nil, validatorName: "TestValidator")
+        ]
+        let report = ValidationReport(findings: findings)
+        let output = report.formatted(style: .terminal)
+
+        #expect(output.contains("Missing title"))
+        #expect(output.contains("error"))
+    }
+
+    @Test("Xcode format includes file path")
+    func xcodeFormat() {
+        let findings = [
+            ValidationRule(severity: .warning, message: "No image", source: "/blog/post", target: nil, validatorName: "TestValidator")
+        ]
+        let report = ValidationReport(findings: findings)
+        let output = report.formatted(style: .xcode)
+
+        #expect(output.contains("/blog/post"))
+        #expect(output.contains("warning"))
+        #expect(output.contains("No image"))
+    }
+
+    // MARK: - ValidationMode
+
+    @Test("All validation modes exist")
+    func validationModes() {
+        let modes: [ValidationMode] = [.disabled, .warn, .strict]
+        #expect(modes.count == 3)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ValidationSeverity` (info/warning/error) with `Comparable`
- Adds `ValidationRule` for individual findings and `ValidationReport` with terminal and Xcode-compatible formatting
- Adds `ValidationMode` (disabled/warn/strict) for controlling build behavior
- Adds `SiteValidator` protocol operating on `[Article]` arrays
- Adds `RequiredMetadataValidator` for checking front matter fields
- 17 new tests covering severity ordering, report filtering, formatting, and validator behavior

## Design
Purely additive — new `Sources/Ignite/Validation/` directory. Validators take `[Article]` as input rather than requiring `PublishingContext`, making them immediately testable. Pipeline integration and additional validators (BrokenLink, MissingImage) are planned as follow-ups.

## Test plan
- [x] All 17 new tests pass
- [x] Full test suite passes (1353 tests)
- [x] `swift build` clean with no warnings