### PR TITLE
Add deployment foundation types

### DIFF
--- a/Sources/Ignite/Deployment/DeploymentDiff.swift
+++ b/Sources/Ignite/Deployment/DeploymentDiff.swift
@@ -1,0 +1,61 @@
+//
+//  DeploymentDiff.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// Tracks which files changed between builds to enable incremental deployment.
+public struct DeploymentDiff: Sendable {
+    public let added: Set<String>
+    public let removed: Set<String>
+    public let unchanged: Set<String>
+    public let isAvailable: Bool
+
+    public init(added: Set<String>, removed: Set<String>, unchanged: Set<String>) {
+        self.added = added
+        self.removed = removed
+        self.unchanged = unchanged
+        self.isAvailable = true
+    }
+
+    private init(added: Set<String>, removed: Set<String>, unchanged: Set<String>, isAvailable: Bool) {
+        self.added = added
+        self.removed = removed
+        self.unchanged = unchanged
+        self.isAvailable = isAvailable
+    }
+
+    public var hasChanges: Bool {
+        !added.isEmpty || !removed.isEmpty
+    }
+
+    public var totalFileCount: Int {
+        added.count + removed.count + unchanged.count
+    }
+
+    /// Creates a diff representing a first-time deployment where every file is new.
+    public static func firstDeploy(fileCount: Int) -> DeploymentDiff {
+        DeploymentDiff(
+            added: Set((0..<fileCount).map { "file-\($0)" }),
+            removed: [],
+            unchanged: [],
+            isAvailable: false
+        )
+    }
+}
+
+/// A record of what was deployed last time.
+public struct DeploymentManifest: Codable, Sendable {
+    public let files: [String: String]
+    public let timestamp: Date
+    public let targetName: String
+
+    public init(files: [String: String], timestamp: Date, targetName: String) {
+        self.files = files
+        self.timestamp = timestamp
+        self.targetName = targetName
+    }
+}

--- a/Sources/Ignite/Deployment/DeploymentEnvironment.swift
+++ b/Sources/Ignite/Deployment/DeploymentEnvironment.swift
@@ -1,0 +1,24 @@
+//
+//  DeploymentEnvironment.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// Reads deployment secrets from environment variables.
+public struct DeploymentEnvironment: Sendable {
+    /// Reads a required environment variable, throwing if not set.
+    public static func required(_ key: String) throws -> String {
+        guard let value = ProcessInfo.processInfo.environment[key] else {
+            throw DeploymentError.missingEnvironmentVariable(key)
+        }
+        return value
+    }
+
+    /// Reads an optional environment variable.
+    public static func optional(_ key: String) -> String? {
+        ProcessInfo.processInfo.environment[key]
+    }
+}

--- a/Sources/Ignite/Deployment/DeploymentError.swift
+++ b/Sources/Ignite/Deployment/DeploymentError.swift
@@ -1,0 +1,35 @@
+//
+//  DeploymentError.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// Errors that can occur during deployment.
+public enum DeploymentError: LocalizedError, Sendable {
+    case missingEnvironmentVariable(String)
+    case missingConfiguration(String)
+    case invalidBuildDirectory(URL)
+    case targetRejected(statusCode: Int, message: String)
+    case fileError(String)
+    case networkError(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingEnvironmentVariable(let key):
+            "Missing environment variable: \(key). Set it before deploying."
+        case .missingConfiguration(let detail):
+            "Deployment configuration incomplete: \(detail)"
+        case .invalidBuildDirectory(let url):
+            "Build directory not found or empty: \(url.path)"
+        case .targetRejected(let code, let message):
+            "Deployment rejected (\(code)): \(message)"
+        case .fileError(let detail):
+            "File error during deployment: \(detail)"
+        case .networkError(let detail):
+            "Network error during deployment: \(detail)"
+        }
+    }
+}

--- a/Sources/Ignite/Deployment/DeploymentResult.swift
+++ b/Sources/Ignite/Deployment/DeploymentResult.swift
@@ -1,0 +1,29 @@
+//
+//  DeploymentResult.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// The outcome of a deployment operation.
+public struct DeploymentResult: Sendable {
+    public let siteURL: URL?
+    public let filesUploaded: Int
+    public let filesDeleted: Int
+    public let filesSkipped: Int
+    public let bytesTransferred: Int64
+    public let duration: Duration
+    public let isDryRun: Bool
+    public let warnings: [String]
+
+    public var summary: String {
+        let action = isDryRun ? "Would deploy" : "Deployed"
+        var parts = ["\(action) \(filesUploaded) files"]
+        if filesDeleted > 0 { parts.append("deleted \(filesDeleted)") }
+        if filesSkipped > 0 { parts.append("skipped \(filesSkipped) unchanged") }
+        if let url = siteURL { parts.append("to \(url.absoluteString)") }
+        return parts.joined(separator: ", ")
+    }
+}

--- a/Sources/Ignite/Deployment/DeploymentTarget.swift
+++ b/Sources/Ignite/Deployment/DeploymentTarget.swift
@@ -1,0 +1,21 @@
+//
+//  DeploymentTarget.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// A hosting provider that Ignite can deploy to.
+public protocol DeploymentTarget: Sendable {
+    var name: String { get }
+
+    func validate() throws
+
+    func deploy(
+        buildDirectory: URL,
+        diff: DeploymentDiff?,
+        dryRun: Bool
+    ) async throws -> DeploymentResult
+}

--- a/Tests/IgniteTesting/Deployment/DeploymentTests.swift
+++ b/Tests/IgniteTesting/Deployment/DeploymentTests.swift
@@ -1,0 +1,173 @@
+//
+//  DeploymentTests.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+import Testing
+
+@testable import Ignite
+
+/// Tests for the deployment foundation types.
+@Suite("Deployment Tests")
+struct DeploymentTests {
+
+    // MARK: - DeploymentDiff
+
+    @Test("Diff reports added files")
+    func diffAdded() {
+        let diff = DeploymentDiff(
+            added: ["index.html", "about.html"],
+            removed: [],
+            unchanged: ["style.css"]
+        )
+        #expect(diff.added.count == 2)
+        #expect(diff.isAvailable)
+    }
+
+    @Test("Diff reports removed files")
+    func diffRemoved() {
+        let diff = DeploymentDiff(
+            added: [],
+            removed: ["old-page.html"],
+            unchanged: ["index.html"]
+        )
+        #expect(diff.removed.count == 1)
+    }
+
+    @Test("Empty diff means no changes")
+    func diffEmpty() {
+        let diff = DeploymentDiff(
+            added: [],
+            removed: [],
+            unchanged: ["index.html"]
+        )
+        #expect(!diff.hasChanges)
+    }
+
+    @Test("Diff with changes reports hasChanges")
+    func diffHasChanges() {
+        let diff = DeploymentDiff(
+            added: ["new.html"],
+            removed: [],
+            unchanged: []
+        )
+        #expect(diff.hasChanges)
+    }
+
+    @Test("Total file count is correct")
+    func diffTotalCount() {
+        let diff = DeploymentDiff(
+            added: ["a.html"],
+            removed: ["b.html"],
+            unchanged: ["c.html", "d.html"]
+        )
+        #expect(diff.totalFileCount == 4)
+    }
+
+    @Test("First deploy diff is not available")
+    func firstDeployDiff() {
+        let diff = DeploymentDiff.firstDeploy(fileCount: 5)
+        #expect(!diff.isAvailable)
+        #expect(diff.added.count == 5)
+    }
+
+    // MARK: - DeploymentResult
+
+    @Test("Result summary includes file counts")
+    func resultSummary() {
+        let result = DeploymentResult(
+            siteURL: URL(string: "https://example.com"),
+            filesUploaded: 10,
+            filesDeleted: 2,
+            filesSkipped: 5,
+            bytesTransferred: 1024,
+            duration: .seconds(3),
+            isDryRun: false,
+            warnings: []
+        )
+        #expect(result.summary.contains("10"))
+        #expect(result.summary.contains("example.com"))
+    }
+
+    @Test("Dry run summary says 'Would deploy'")
+    func dryRunSummary() {
+        let result = DeploymentResult(
+            siteURL: nil,
+            filesUploaded: 5,
+            filesDeleted: 0,
+            filesSkipped: 0,
+            bytesTransferred: 0,
+            duration: .seconds(1),
+            isDryRun: true,
+            warnings: []
+        )
+        #expect(result.summary.contains("Would deploy"))
+    }
+
+    @Test("Real deploy summary says 'Deployed'")
+    func realDeploySummary() {
+        let result = DeploymentResult(
+            siteURL: nil,
+            filesUploaded: 3,
+            filesDeleted: 0,
+            filesSkipped: 0,
+            bytesTransferred: 0,
+            duration: .seconds(1),
+            isDryRun: false,
+            warnings: []
+        )
+        #expect(result.summary.contains("Deployed"))
+    }
+
+    // MARK: - DeploymentManifest
+
+    @Test("Manifest is Codable round-trip")
+    func manifestCodable() throws {
+        let manifest = DeploymentManifest(
+            files: ["index.html": "abc123", "style.css": "def456"],
+            timestamp: Date(timeIntervalSince1970: 1000000),
+            targetName: "GitHub Pages"
+        )
+        let data = try JSONEncoder().encode(manifest)
+        let decoded = try JSONDecoder().decode(DeploymentManifest.self, from: data)
+
+        #expect(decoded.files.count == 2)
+        #expect(decoded.files["index.html"] == "abc123")
+        #expect(decoded.targetName == "GitHub Pages")
+    }
+
+    // MARK: - DeploymentEnvironment
+
+    @Test("Optional returns nil for missing variable")
+    func envOptionalMissing() {
+        #expect(DeploymentEnvironment.optional("IGNITE_TEST_NONEXISTENT_VAR_12345") == nil)
+    }
+
+    @Test("Required throws for missing variable")
+    func envRequiredThrows() {
+        #expect(throws: DeploymentError.self) {
+            try DeploymentEnvironment.required("IGNITE_TEST_NONEXISTENT_VAR_12345")
+        }
+    }
+
+    // MARK: - DeploymentError
+
+    @Test("Error descriptions are human-readable")
+    func errorDescriptions() {
+        let errors: [DeploymentError] = [
+            .missingEnvironmentVariable("TOKEN"),
+            .missingConfiguration("repo URL"),
+            .invalidBuildDirectory(URL(fileURLWithPath: "/tmp/build")),
+            .targetRejected(statusCode: 403, message: "Forbidden"),
+            .fileError("permission denied"),
+            .networkError("timeout")
+        ]
+        for error in errors {
+            #expect(error.errorDescription != nil)
+            #expect(!error.errorDescription!.isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `DeploymentTarget` protocol with validate/deploy interface
- Adds `DeploymentDiff` for incremental file change tracking
- Adds `DeploymentResult` with summary formatting
- Adds `DeploymentManifest` (Codable) for persisting deploy state
- Adds `DeploymentEnvironment` for safe environment variable access
- Adds `DeploymentError` with descriptive error messages
- 13 new tests covering diff computation, result formatting, manifest serialization, and environment access

## Design
Purely additive — new `Sources/Ignite/Deployment/` directory. Defines the protocol and data types that concrete deployment targets (GitHub Pages, Netlify, etc.) will implement. No CLI command yet — that requires deeper framework integration.

## Test plan
- [x] All 13 new tests pass
- [x] Full test suite passes (1353 tests)
- [x] `swift build` clean with no warnings