### PR TITLE
Add design token foundation

### DIFF
--- a/Sources/Ignite/DesignSystem/CSSGenerator.swift
+++ b/Sources/Ignite/DesignSystem/CSSGenerator.swift
@@ -1,0 +1,32 @@
+//
+//  CSSGenerator.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// Compiles design tokens to CSS custom properties.
+public enum CSSGenerator {
+    /// Generates a `:root` block with CSS custom properties from the given tokens.
+    public static func generate(from tokens: [AnyDesignToken]) -> String {
+        var lines = [":root {"]
+        for token in tokens {
+            lines.append("  \(token.cssProperty): \(token.cssValue);")
+        }
+        lines.append("}")
+        return lines.joined(separator: "\n")
+    }
+
+    /// Generates a `prefers-color-scheme: dark` media query with token overrides.
+    public static func generateDarkMode(from overrides: [AnyDesignToken]) -> String {
+        var lines = ["@media (prefers-color-scheme: dark) {", "  :root {"]
+        for token in overrides {
+            lines.append("    \(token.cssProperty): \(token.cssValue);")
+        }
+        lines.append("  }")
+        lines.append("}")
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Sources/Ignite/DesignSystem/DesignToken.swift
+++ b/Sources/Ignite/DesignSystem/DesignToken.swift
@@ -1,0 +1,55 @@
+//
+//  DesignToken.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// A value that can be expressed as a CSS value.
+public protocol TokenValue: Sendable {
+    var cssValue: String { get }
+}
+
+/// Categories of design tokens.
+public enum TokenCategory: String, Sendable {
+    case color
+    case spacing = "space"
+    case typography = "type"
+    case shadow
+    case radius
+    case breakpoint = "bp"
+}
+
+/// A typed design token that compiles to a CSS custom property.
+public struct DesignToken<Value: TokenValue>: Sendable {
+    public let name: String
+    public let category: TokenCategory
+    public let value: Value
+
+    public var cssProperty: String {
+        "--ig-\(category.rawValue)-\(name)"
+    }
+
+    public var cssVar: String {
+        "var(\(cssProperty))"
+    }
+
+    public init(name: String, category: TokenCategory, value: Value) {
+        self.name = name
+        self.category = category
+        self.value = value
+    }
+
+    /// Type-erases this token for use in heterogeneous collections.
+    public var erased: AnyDesignToken {
+        AnyDesignToken(cssProperty: cssProperty, cssValue: value.cssValue)
+    }
+}
+
+/// A type-erased design token for heterogeneous collections.
+public struct AnyDesignToken: Sendable {
+    public let cssProperty: String
+    public let cssValue: String
+}

--- a/Sources/Ignite/DesignSystem/TokenValues.swift
+++ b/Sources/Ignite/DesignSystem/TokenValues.swift
@@ -1,0 +1,125 @@
+//
+//  TokenValues.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+
+/// A color value in the design system.
+public struct ColorValue: TokenValue, Sendable {
+    public let red: Int
+    public let green: Int
+    public let blue: Int
+    public let alpha: Double
+
+    public var cssValue: String {
+        alpha < 1.0
+            ? "rgba(\(red), \(green), \(blue), \(alpha))"
+            : "rgb(\(red), \(green), \(blue))"
+    }
+
+    public init(red: Int, green: Int, blue: Int, alpha: Double = 1.0) {
+        self.red = red
+        self.green = green
+        self.blue = blue
+        self.alpha = alpha
+    }
+
+    public init(hex: String) {
+        let cleaned = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+        guard cleaned.count == 6,
+              let value = UInt32(cleaned, radix: 16) else {
+            self.init(red: 0, green: 0, blue: 0)
+            return
+        }
+        self.init(
+            red: Int((value >> 16) & 0xFF),
+            green: Int((value >> 8) & 0xFF),
+            blue: Int(value & 0xFF)
+        )
+    }
+}
+
+/// A spacing value in the design system.
+public struct SpacingValue: TokenValue, Sendable {
+    public let rem: Double
+
+    public var cssValue: String { "\(rem)rem" }
+
+    public init(rem: Double) {
+        self.rem = rem
+    }
+
+    /// Creates a spacing token from a scale step (1 = 0.25rem, 4 = 1rem, 16 = 4rem).
+    public static func scale(_ step: Int) -> DesignToken<SpacingValue> {
+        DesignToken(
+            name: "\(step)",
+            category: .spacing,
+            value: SpacingValue(rem: Double(step) * 0.25)
+        )
+    }
+}
+
+/// A typography value combining font properties.
+public struct TypographyValue: TokenValue, Sendable {
+    public let fontFamily: String
+    public let fontSize: Double
+    public let fontWeight: Int
+    public let lineHeight: Double
+    public let letterSpacing: Double
+
+    public var cssValue: String {
+        "\(fontWeight) \(fontSize)rem/\(lineHeight) \(fontFamily)"
+    }
+
+    public init(fontFamily: String, fontSize: Double, fontWeight: Int, lineHeight: Double, letterSpacing: Double) {
+        self.fontFamily = fontFamily
+        self.fontSize = fontSize
+        self.fontWeight = fontWeight
+        self.lineHeight = lineHeight
+        self.letterSpacing = letterSpacing
+    }
+}
+
+/// A shadow value for elevation.
+public struct ShadowValue: TokenValue, Sendable {
+    public let x: Double
+    public let y: Double
+    public let blur: Double
+    public let spread: Double
+    public let color: ColorValue
+
+    public var cssValue: String {
+        "\(x)px \(y)px \(blur)px \(spread)px \(color.cssValue)"
+    }
+
+    public init(x: Double, y: Double, blur: Double, spread: Double, color: ColorValue) {
+        self.x = x
+        self.y = y
+        self.blur = blur
+        self.spread = spread
+        self.color = color
+    }
+}
+
+/// A border radius value.
+public struct RadiusValue: TokenValue, Sendable {
+    public let rem: Double
+    public var cssValue: String { "\(rem)rem" }
+
+    public init(rem: Double) {
+        self.rem = rem
+    }
+}
+
+/// A responsive breakpoint value.
+public struct BreakpointValue: TokenValue, Sendable {
+    public let minWidth: Int
+    public var cssValue: String { "\(minWidth)px" }
+
+    public init(minWidth: Int) {
+        self.minWidth = minWidth
+    }
+}

--- a/Tests/IgniteTesting/DesignSystem/DesignTokenTests.swift
+++ b/Tests/IgniteTesting/DesignSystem/DesignTokenTests.swift
@@ -1,0 +1,155 @@
+//
+//  DesignTokenTests.swift
+//  Ignite
+//  https://www.github.com/twostraws/Ignite
+//  See LICENSE for license information.
+//
+
+import Foundation
+import Testing
+
+@testable import Ignite
+
+/// Tests for design token types and CSS generation.
+@Suite("DesignToken Tests")
+struct DesignTokenTests {
+
+    // MARK: - DesignToken
+
+    @Test("Token generates correct CSS property name")
+    func tokenCSSProperty() {
+        let token = DesignToken(name: "primary", category: .color, value: ColorValue(red: 255, green: 0, blue: 0))
+        #expect(token.cssProperty == "--ig-color-primary")
+    }
+
+    @Test("Token generates correct CSS var reference")
+    func tokenCSSVar() {
+        let token = DesignToken(name: "sm", category: .spacing, value: SpacingValue(rem: 0.25))
+        #expect(token.cssVar == "var(--ig-space-sm)")
+    }
+
+    // MARK: - ColorValue
+
+    @Test("RGB color generates correct CSS")
+    func colorRGB() {
+        let color = ColorValue(red: 100, green: 200, blue: 50)
+        #expect(color.cssValue == "rgb(100, 200, 50)")
+    }
+
+    @Test("RGBA color includes alpha")
+    func colorRGBA() {
+        let color = ColorValue(red: 100, green: 200, blue: 50, alpha: 0.5)
+        #expect(color.cssValue == "rgba(100, 200, 50, 0.5)")
+    }
+
+    @Test("Hex initialization parses correctly")
+    func colorHex() {
+        let color = ColorValue(hex: "#FF6B35")
+        #expect(color.red == 255)
+        #expect(color.green == 107)
+        #expect(color.blue == 53)
+    }
+
+    @Test("Hex without hash parses correctly")
+    func colorHexNoHash() {
+        let color = ColorValue(hex: "0066CC")
+        #expect(color.red == 0)
+        #expect(color.green == 102)
+        #expect(color.blue == 204)
+    }
+
+    @Test("Invalid hex defaults to black")
+    func colorHexInvalid() {
+        let color = ColorValue(hex: "invalid")
+        #expect(color.red == 0)
+        #expect(color.green == 0)
+        #expect(color.blue == 0)
+    }
+
+    // MARK: - SpacingValue
+
+    @Test("Spacing generates rem CSS")
+    func spacingCSS() {
+        let spacing = SpacingValue(rem: 1.5)
+        #expect(spacing.cssValue == "1.5rem")
+    }
+
+    @Test("Spacing scale generates expected values")
+    func spacingScale() {
+        let step4 = SpacingValue.scale(4)
+        #expect(step4.value.rem == 1.0)
+        #expect(step4.name == "4")
+    }
+
+    // MARK: - TypographyValue
+
+    @Test("Typography generates CSS shorthand")
+    func typographyCSS() {
+        let typo = TypographyValue(
+            fontFamily: "Inter, sans-serif",
+            fontSize: 1.0,
+            fontWeight: 400,
+            lineHeight: 1.5,
+            letterSpacing: 0.0
+        )
+        #expect(typo.cssValue == "400 1.0rem/1.5 Inter, sans-serif")
+    }
+
+    // MARK: - ShadowValue
+
+    @Test("Shadow generates correct CSS")
+    func shadowCSS() {
+        let shadow = ShadowValue(
+            x: 0, y: 2, blur: 4, spread: 0,
+            color: ColorValue(red: 0, green: 0, blue: 0, alpha: 0.1)
+        )
+        #expect(shadow.cssValue.contains("0.0px 2.0px 4.0px 0.0px"))
+        #expect(shadow.cssValue.contains("rgba(0, 0, 0, 0.1)"))
+    }
+
+    // MARK: - RadiusValue
+
+    @Test("Radius generates rem CSS")
+    func radiusCSS() {
+        let radius = RadiusValue(rem: 0.5)
+        #expect(radius.cssValue == "0.5rem")
+    }
+
+    // MARK: - BreakpointValue
+
+    @Test("Breakpoint generates px CSS")
+    func breakpointCSS() {
+        let bp = BreakpointValue(minWidth: 768)
+        #expect(bp.cssValue == "768px")
+    }
+
+    // MARK: - CSSGenerator
+
+    @Test("Generates CSS custom properties from tokens")
+    func generateCSS() {
+        let tokens: [AnyDesignToken] = [
+            DesignToken(name: "primary", category: .color, value: ColorValue(hex: "#FF6B35")).erased,
+            DesignToken(name: "1", category: .spacing, value: SpacingValue(rem: 0.25)).erased
+        ]
+        let css = CSSGenerator.generate(from: tokens)
+        #expect(css.contains("--ig-color-primary"))
+        #expect(css.contains("--ig-space-1"))
+        #expect(css.contains(":root"))
+    }
+
+    @Test("Empty tokens generates minimal CSS")
+    func generateEmptyCSS() {
+        let css = CSSGenerator.generate(from: [])
+        #expect(css.contains(":root"))
+    }
+
+    @Test("Generates media query for dark mode overrides")
+    func generateDarkMode() {
+        let overrides: [AnyDesignToken] = [
+            DesignToken(name: "background", category: .color, value: ColorValue(hex: "#1a1a1a")).erased
+        ]
+        let css = CSSGenerator.generateDarkMode(from: overrides)
+        #expect(css.contains("prefers-color-scheme: dark"))
+        #expect(css.contains("--ig-color-background"))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds generic `DesignToken<Value>` type with CSS custom property generation (`--ig-{category}-{name}`)
- Adds `TokenCategory` enum and `TokenValue` protocol
- Adds concrete value types: `ColorValue` (with hex parsing), `SpacingValue` (with scale helper), `TypographyValue`, `ShadowValue`, `RadiusValue`, `BreakpointValue`
- Adds `AnyDesignToken` type erasure for heterogeneous collections
- Adds `CSSGenerator` for compiling tokens to `:root` CSS custom properties with dark mode media query support
- 16 new tests covering all token types, CSS generation, and hex color parsing

## Design
Purely additive — new `Sources/Ignite/DesignSystem/` directory. These are the atomic building blocks for a future `DesignSystem` protocol that could replace Bootstrap dependency. The token types are independent of any existing framework code.

## Test plan
- [x] All 16 new tests pass
- [x] Full test suite passes (1353 tests)
- [x] `swift build` clean with no warnings